### PR TITLE
Fix possible buffer overflow in M_LoadDefaults

### DIFF
--- a/m_misc.c
+++ b/m_misc.c
@@ -353,7 +353,7 @@ void M_LoadDefaults(void)
         while (!feof(f))
         {
             isstring = false;
-            if (fscanf(f, "%79s %[^\n]\n", def, strparm) == 2)
+            if (fscanf(f, "%79s %99[^\n]\n", def, strparm) == 2)
             {
                 if (strparm[0] == '"')
                 {


### PR DESCRIPTION
The amount of data written to `strparm` is not limited as it should. 