### PR TITLE
P_PointOnLineSide/P_PointOnDivlineSide optimization

### DIFF
--- a/FASTDOOM/p_maputl.c
+++ b/FASTDOOM/p_maputl.c
@@ -57,17 +57,11 @@ byte P_PointOnLineSide(fixed_t x, fixed_t y, line_t *line)
 
     if (!line->dx)
     {
-        if (x <= line->v1->x)
-            return line->dy > 0;
-
-        return line->dy < 0;
+        return (x <= line->v1->x) ^ (line->dy <= 0);
     }
     if (!line->dy)
     {
-        if (y <= line->v1->y)
-            return line->dx < 0;
-
-        return line->dx > 0;
+        return (y <= line->v1->y) ^ (line->dx >= 0);
     }
 
     dx = (x - line->v1->x);
@@ -141,17 +135,11 @@ byte P_PointOnDivlineSide(fixed_t x,
 
     if (!line->dx)
     {
-        if (x <= line->x)
-            return line->dy > 0;
-
-        return line->dy < 0;
+        return (x <= line->x) ^ (line->dy <= 0);
     }
     if (!line->dy)
     {
-        if (y <= line->y)
-            return line->dx < 0;
-
-        return line->dx > 0;
+        return (y <= line->y) ^ (line->dx >= 0);
     }
 
     dx = (x - line->x);


### PR DESCRIPTION
I assume that the divline_t and line_t will not be zero length.
If it is then the return values is still valid but may be different than vanilla behavior that would always return 0 when both `dx` and `dy` are zero.

I checked on the three demo from Ultimate Doom, no desync I do not know for sure if zero-length lines can ever put in those functions. You be the judge.