### PR TITLE
Reimplement "move forward" mouse button function

### DIFF
--- a/FASTDOOM/g_game.c
+++ b/FASTDOOM/g_game.c
@@ -186,7 +186,7 @@ void G_BuildTiccmd(ticcmd_t *cmd)
 
     forward = 0;
 
-    if (gamekeydown[key_up])
+    if (gamekeydown[key_up] || mousebuttons[mousebforward])
     {
         forward += forwardmove[speed];
     }


### PR DESCRIPTION
The mouse button functionality for being able to move forward has never worked in Fastdoom as far as I'm aware, most likely because it was ripped out while joystick support was removed. This PR restores the functionality of being able to use the "move forward" mouse button that is available in FDSETUP and the vanilla SETUP executables.

Tested on:

- DOSBox Staging 0.77.1
- Kensington Expert Mouse via serial and PS/2 on a ASUS CUBX-L (Intel 440BX chipset) socket 370 motherboard with 1.4Ghz Tualatin Celeron processor, using the CTMOUSE driver
- Kensington Expert Mouse via serial on a DTK PEM-3330Y (Haydn Symphony chipset) 386 motherboard with a 386DX-40, using the CTMOUSE driver

Third time lucky with this PR.