### PR TITLE
Fix music volume initialising at double volume

### DIFF
--- a/FASTDOOM/dmx.c
+++ b/FASTDOOM/dmx.c
@@ -136,7 +136,7 @@ void MUS_PlaySong(int handle, int volume)
         return;
     }
     MUSIC_PlaySong((unsigned char *)mus_data, mus_loop);
-    MUSIC_SetVolume(volume * 2);
+    MUSIC_SetVolume(volume);
 }
 
 int SFX_PlayPatch(void *vdata, int sep, int vol)


### PR DESCRIPTION
Music always initialises at double volume, which can cause a lot of discomfort when the volume for sound and music has been tweaked and suddenly the music starts blasting at a much louder volume than expected.

Tested this on various Sound Blaster-compatible sound cards, via Adlib/Sound Blaster and General Midi/Waveblaster.