### PR TITLE
Fix desync in DEMO4

### DIFF
--- a/FASTDOOM/p_enemy.c
+++ b/FASTDOOM/p_enemy.c
@@ -473,6 +473,7 @@ void P_NewChaseDir(mobj_t *actor)
 
 //
 // P_LookForPlayers
+// Here we return 1 if lookup faile
 //
 
 byte P_LookForPlayers(mobj_t *actor)
@@ -481,6 +482,11 @@ byte P_LookForPlayers(mobj_t *actor)
     int stop;
     angle_t an;
     fixed_t dist;
+
+    stop = (actor->lastlook - 1) & 3;
+    actor->lastlook = 0;
+    if(stop == 0)
+        return 1;
 
     if (players.health <= 0 || !P_CheckSight(actor, players_mo))
         return 1; // dead, out of sight
@@ -498,13 +504,18 @@ byte P_LookForPlayers(mobj_t *actor)
     actor->target = players_mo;
     return 0;
 }
-
+// Here we return 0 if lookup fails!
 byte P_LookForPlayersAllAround(mobj_t *actor)
 {
     int c;
     int stop;
     angle_t an;
     fixed_t dist;
+
+    stop = (actor->lastlook - 1) & 3;
+    actor->lastlook = 0;
+    if(stop == 0)
+        return 0;
 
     if (players.health <= 0 || !P_CheckSight(actor, players_mo))
         return 0; // dead, out of sight

--- a/FASTDOOM/p_mobj.c
+++ b/FASTDOOM/p_mobj.c
@@ -463,8 +463,8 @@ P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, byte type)
     if (gameskill != sk_nightmare)
         mobj->reactiontime = info->reactiontime;
 
-    //mobj->lastlook = P_Random & 0;
-    P_Random;
+    mobj->lastlook = P_Random & (MAXPLAYERS - 1); // MAXPLAYERS=4
+
     // do not set the state with P_SetMobjState,
     // because action routines can not be called yet
     st = &states[info->spawnstate];

--- a/FASTDOOM/p_mobj.h
+++ b/FASTDOOM/p_mobj.h
@@ -261,6 +261,9 @@ typedef struct mobj_s
     // Only valid if type == MT_PLAYER
     struct player_s *player;
 
+    // Player number last looked for.
+    int lastlook;
+
     // For nightmare respawn.
     mapthing_t spawnpoint;
 


### PR DESCRIPTION
Fix Regression introduced by 3329d70
Fixes #100 

I think we cannot get rid of the `lastlook` variable in mobj_s, because it introduces a random value that can skip the check. I guess it is not so big on resource.

It took me a while to figure out that the newer `P_LookForPlayers()` has to return 1 for false.
Also for the `P_LookForPlayersAllAround()` we must return 0 for false, as expected, might have used a rename, like `P_LookForPlayersNot()` or something, I understand you want to save one not instruction...
I guess also that there is a beter solution but at least now it does not desync demo4
I also tested playing back ep4-342.lmp by Dsparil and it works fine.