### PR TITLE
Condition 'sb' was allways true

### DIFF
--- a/FASTDOOM/i_sound.c
+++ b/FASTDOOM/i_sound.c
@@ -133,7 +133,7 @@ void I_sndArbitrateCards(void)
     // figure out what i've got to initialize
     //
     gus = snd_MusicDevice == snd_GUS || snd_SfxDevice == snd_GUS;
-    sb = snd_SfxDevice == snd_SB || snd_SBDirect;
+    sb = snd_SfxDevice == snd_SB || snd_SfxDevice == snd_SBDirect;
     ensoniq = snd_SfxDevice == snd_ENSONIQ;
     adlib = snd_MusicDevice == snd_Adlib || snd_MusicDevice == snd_SB || snd_MusicDevice == snd_PAS;
     oplxlpt = snd_MusicDevice == snd_OPL2LPT || snd_MusicDevice == snd_OPL3LPT;


### PR DESCRIPTION
Condition  `sb = snd_SfxDevice == snd_SB ||  snd_SBDirect;` was allways true. So, SB_Detect(); allways called regardless of settings.