### PR TITLE
Add high resolution VESA 2.0 Graphics modes with improved debugging and build facilities

### DIFF
--- a/FASTDOOM/Makefile.gnu
+++ b/FASTDOOM/Makefile.gnu
@@ -1,0 +1,213 @@
+
+# FDOOM.EXE makefile
+
+# --------------------------------------------------------------------------
+#
+#      4r  use 80486 timings and register argument passing
+#       c  compile only
+#      d1  include line number debugging information
+#      d2  include full sybolic debugging information
+#      ei  force enums to be of type int
+#       j  change char default from unsigned to signed
+#      oa  relax aliasing checking
+#      od  do not optimize
+#  oe[=#]  expand functions inline, # = quads (default 20)
+#      oi  use the inline library functions
+#      om  generate inline 80x87 code for math functions
+#      ot  optimize for time
+#      ox  maximum optimization
+#       s  remove stack overflow checks
+#     zp1  align structures on bytes
+#      zq  use quiet mode
+#  /i=dir  add include directories
+#
+# --------------------------------------------------------------------------
+
+# Build options for 486DX/SX
+#CCOPTS = $(EXTERNOPT) -omaxtnrih -ol+ -oe=32 -zp4 -4r -ei -j -zq -zc $(WCCOPTS)
+
+# Build options for 386DX/SX
+CCOPTS = $(EXTERNOPT) -omaxtnrih -ol+ -oe=32 -zp4 -3r -ei -j -zq -zc $(WCCOPTS)
+
+# Build options for Pentium
+#CCOPTS = $(EXTERNOPT) -omaxtnrih -ol+ -oe=32 -zp4 -5r -ei -j -zq -zc $(WCCOPTS)
+
+# Build options for profiling (Pentium required)
+#CCOPTS = $(EXTERNOPT) -omaxtnrih -ol+ -oe=32 -zp4 -5r -ei -j -zq -zc -et $(WCCOPTS)
+
+NASMOPTS = $(EXTERNOPT) $(NASMOPT)
+
+GLOBOBJS = \
+ i_cgaafh.obj \
+ cgaafh.obj \
+ i_cga16.obj \
+ cga16.obj \
+ i_vga.obj \
+ i_vga13h.obj \
+ vga13h.obj \
+ i_pcp.obj \
+ pcp.obj \
+ i_sigma.obj \
+ sigma.obj \
+ i_cga4.obj \
+ cga4.obj \
+ i_cgacvb.obj \
+ cgacvb.obj \
+ i_herc.obj \
+ herc.obj \
+ i_cgabw.obj \
+ cgabw.obj \
+ i_ega320.obj \
+ ega320.obj \
+ i_vesa.obj \
+ i_cga512.obj \
+ cga512.obj \
+ i_text.obj \
+ i_mda.obj \
+ i_vgay.obj \
+ math.obj \
+ ns_dpmi.obj \
+ ns_pcfx.obj \
+ ns_task.obj \
+ ns_llm.obj \
+ ns_dma.obj \
+ ns_irq.obj \
+ ns_user.obj \
+ ns_mp401.obj \
+ ns_sb.obj \
+ ns_sbmus.obj \
+ ns_sbmid.obj \
+ ns_pas16.obj \
+ ns_mix.obj \
+ ns_gmtbr.obj \
+ ns_scape.obj \
+ ns_awe32.obj \
+ ns_dsney.obj \
+ ns_usrho.obj \
+ ns_gusmi.obj \
+ ns_gusau.obj \
+ ns_gus.obj \
+ ns_midi.obj \
+ ns_music.obj \
+ ns_fxm.obj \
+ ns_multi.obj \
+ ns_speak.obj \
+ ns_pwm.obj \
+ ns_cms.obj \
+ ns_lpt.obj \
+ ns_sbdm.obj \
+ ns_adbfx.obj \
+ ns_tandy.obj \
+ ns_cd.obj \
+ i_debug.obj \
+ i_log.obj \
+ i_random.obj \
+ i_main.obj \
+ i_ibm.obj \
+ i_sound.obj \
+ linearh.obj \
+ linearh2.obj \
+ linearh3.obj \
+ linearhKN.obj \
+ linearhSX.obj \
+ linearl.obj \
+ linearl2.obj \
+ linearl3.obj \
+ linearlKN.obj \
+ linearlSX.obj \
+ linearp.obj \
+ linearp2.obj \
+ linearp3.obj \
+ linearpSX.obj \
+ planar.obj \
+ planar2.obj \
+ planar3.obj \
+ planar4.obj \
+ planarKN.obj \
+ planarSX.obj \
+ vbe2dh.obj \
+ vbe2dh2.obj \
+ vbe2dh3.obj \
+ vbe2dhSX.obj \
+ vbe2dl.obj \
+ vbe2dl2.obj \
+ vbe2dl3.obj \
+ vbe2dlSX.obj \
+ vbe2dp.obj \
+ vbe2dp2.obj \
+ vbe2dp3.obj \
+ vbe2dpSX.obj \
+ tables.obj \
+ f_finale.obj \
+ d_main.obj \
+ d_net.obj \
+ g_game.obj \
+ m_menu.obj \
+ m_bench.obj \
+ m_misc.obj \
+ am_map.obj \
+ p_ceilng.obj \
+ p_doors.obj \
+ p_enemy.obj \
+ p_floor.obj \
+ p_inter.obj \
+ p_lights.obj \
+ p_map.obj \
+ p_maputl.obj \
+ p_plats.obj \
+ p_pspr.obj \
+ p_setup.obj \
+ p_sight.obj \
+ p_spec.obj \
+ p_switch.obj \
+ p_mobj.obj \
+ p_telept.obj \
+ p_saveg.obj \
+ p_tick.obj \
+ p_user.obj \
+ r_bsp.obj \
+ r_data.obj \
+ r_draw.obj \
+ r_main.obj \
+ r_plane.obj \
+ r_segs.obj \
+ r_things.obj \
+ w_wad.obj \
+ v_video.obj \
+ z_zone.obj \
+ st_stuff.obj \
+ st_lib.obj \
+ hu_stuff.obj \
+ hu_lib.obj \
+ wi_stuff.obj \
+ s_sound.obj \
+ sounds.obj \
+ dutils.obj \
+ f_wipe.obj \
+ info.obj \
+ dmx.obj \
+ mus2mid.obj
+
+fdoom.exe : $(GLOBOBJS)
+	wlink @fdoom.lnk
+
+%.obj : %.c
+	wcc386 $(CCOPTS) $^ -fo=$@
+
+%.obj : %.asm
+	nasm -g $(NASMOPTS) -Oxv -f obj $^ -o $@
+
+DELCMD=rm -f
+
+clean:
+	$(DELCMD) *.exe
+	$(DELCMD) *.map
+	$(DELCMD) *.err
+	$(DELCMD) *.obj
+	$(DELCMD) *.sym
+	$(DELCMD) *.EXE
+	$(DELCMD) *.MAP
+	$(DELCMD) *.ERR
+	$(DELCMD) *.OBJ
+	$(DELCMD) *.SYM
+

--- a/FASTDOOM/am_map.c
+++ b/FASTDOOM/am_map.c
@@ -931,11 +931,11 @@ void AM_drawFline(fline_t *fl, int color)
 	register int d;
 
 #if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-#define PUTDOT(xx, yy, cc) screen0[Mul320(yy) + (xx)] = (cc)
+#define PUTDOT(xx, yy, cc) screen0[MulScreenWidth(yy) + (xx)] = (cc)
 #endif
 
 #if defined(USE_BACKBUFFER)
-#define PUTDOT(xx, yy, cc) backbuffer[Mul320(yy) + (xx)] = (cc)
+#define PUTDOT(xx, yy, cc) backbuffer[MulScreenWidth(yy) + (xx)] = (cc)
 #endif
 
 	dx = fl->b.x - fl->a.x;

--- a/FASTDOOM/d_main.c
+++ b/FASTDOOM/d_main.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <conio.h>
+#include "i_debug.h"
 #include <dos.h>
 #include <io.h>
 #include "version.h"
@@ -1457,6 +1458,10 @@ void D_DoomMain(void)
 
     printf("\nFastDoom version " FDOOMVERSION "\n");
     printf("CPU class detected: %d\n", I_GetCPUModel());
+#if DEBUG_ENABLED == 1
+    printf("I_DebugInit: Debugging enabled, loading symbols and initializing channels...\n");
+    I_DebugInit();
+#endif
     printf("P_Init: Checking cmd-line parameters...\n");
 
     p = M_CheckParm("-file");

--- a/FASTDOOM/d_main.c
+++ b/FASTDOOM/d_main.c
@@ -301,12 +301,12 @@ void D_Display(void)
 #if defined(MODE_Y) || defined(USE_BACKBUFFER) || defined(MODE_VBE2_DIRECT)
         if (!automapactive || (automapactive && !fullscreen))
         {
-            redrawsbar = wipe || (viewheight != 200 && fullscreen); // just put away the help screen
+            redrawsbar = wipe || (viewheight != SCREENHEIGHT && fullscreen); // just put away the help screen
             ST_Drawer(screenblocks, redrawsbar);
         }
 #endif
 
-        fullscreen = viewheight == 200;
+        fullscreen = viewheight == SCREENHEIGHT;
         break;
 
     case GS_INTERMISSION:
@@ -375,9 +375,9 @@ void D_Display(void)
 #else
         && !automapactive
 #endif
-        
+
 #endif
-        && scaledviewwidth != 320)
+        && scaledviewwidth != SCREENWIDTH)
     {
         if (menuactive || menuactivestate || !viewactivestate)
             borderdrawcount = 3;
@@ -642,30 +642,7 @@ void D_PageTicker(void)
 //
 void D_PageDrawer(void)
 {
-#if defined(MODE_T4050)
-    V_DrawPatchDirectText4050(0, 0, W_CacheLumpName(pagename, PU_CACHE));
-#endif
-#if defined(MODE_T4025)
-    V_DrawPatchDirectText4025(0, 0, W_CacheLumpName(pagename, PU_CACHE));
-#endif
-#if defined(MODE_T8025)
-    V_DrawPatchDirectText8025(0, 0, W_CacheLumpName(pagename, PU_CACHE));
-#endif
-#if defined(MODE_MDA)
-    V_DrawPatchDirectTextMDA(0, 0, W_CacheLumpName(pagename, PU_CACHE));
-#endif
-#if defined(MODE_T8043)
-    V_DrawPatchDirectText8043(0, 0, W_CacheLumpName(pagename, PU_CACHE));
-#endif
-#if defined(MODE_T8050)
-    V_DrawPatchDirectText8050(0, 0, W_CacheLumpName(pagename, PU_CACHE));
-#endif
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-    V_DrawPatchScreen0(0, 0, W_CacheLumpName(pagename, PU_CACHE));
-#endif
-#if defined(USE_BACKBUFFER)
-    V_DrawPatchDirect(0, 0, W_CacheLumpName(pagename, PU_CACHE));
-#endif
+    V_DrawPatchModeCentered(0, 0, W_CacheLumpName(pagename, PU_CACHE));
 }
 
 //
@@ -1223,12 +1200,12 @@ char demofile[13];
 int D_FileGetFirstInteger(const char* filename) {
     char buffer[1024];
     int firstInteger = -1;
-    
+
     FILE* file = fopen(filename, "r");
-    
+
     if (file == NULL)
         return -1;
-    
+
     if (fgets(buffer, sizeof(buffer), file) != NULL) {
         if (sscanf(buffer, "%u", &firstInteger) != 1) {
             firstInteger = -1;
@@ -1385,7 +1362,7 @@ void D_DoomMain(void)
         }
         if(!strcmp(myargv[p + 1], "single"))
             benchmark_type = 0;
-    }   
+    }
 
     disableDemo = M_CheckParm("-disabledemo");
 
@@ -1535,7 +1512,7 @@ void D_DoomMain(void)
         screenblocks = forceScreenSize;
     }
 
-    
+
 
     M_CheckParmOptionalValue("-flatSpan", &visplaneRender, VISPLANES_FLAT);
     M_CheckParmOptionalValue("-flatterSpan", &visplaneRender, VISPLANES_FLATTER);

--- a/FASTDOOM/defs.inc
+++ b/FASTDOOM/defs.inc
@@ -15,10 +15,29 @@
 ;
 
 SCREEN        equ 0xA0000
-SCREENWIDTH   equ 320
-SCREENHEIGHT  equ 200
-PLANEWIDTH    equ 80
-PLANESIZE     equ 80*200
+
+%ifndef SCREENWIDTH
+%define SCREENWIDTH   320
+%define SCREENHEIGHT  200
+%endif
+
+%include "fastmath.inc"
+
+; Multiplcation macros are split into two parts because we can apply
+; pipelining optimizations by placing operations between the two parts.
+%macro MulScreenWidthStart 2
+MulStart SCREENWIDTH, %1, %2
+%endmacro
+
+%macro MulScreenWidthEnd 1
+MulEnd SCREENWIDTH, %1
+%endmacro
+
+PLANEWIDTH    equ SCREENWIDTH/4
+;PLANEWIDTH    equ 80
+;PLANEHEIGHT   equ 120 ; Not sure why this was 120 at some point
+
+PLANESIZE     equ PLANEWIDTH*SCREENHEIGHT
 
 PEL_WRITE_ADR  equ 0x3C8
 PEL_DATA       equ 0x3C9

--- a/FASTDOOM/doomdef.h
+++ b/FASTDOOM/doomdef.h
@@ -55,26 +55,102 @@ typedef enum
   none
 } gamemission_t;
 
-//
-// For resize of screen, at start of game.
-// It will not work dynamically, see visplanes.
-//
-#define BASE_WIDTH 320
-
-// It is educational but futile to change this
-//  scaling e.g. to 2. Drawing of status bar,
-//  menues etc. is tied to the scale implied
-//  by the graphics.
-#define SCREEN_MUL 1
-#define INV_ASPECT_RATIO 0.625 // 0.75, ideally
 
 // Defines suck. C sucks.
 // C++ might sucks for OOP, but it sure is a better C.
 // So there.
+// If we don't override the screen resolution, use the ubiqitous 320x200
+#if !defined(SCREENWIDTH) || !defined(SCREENHEIGHT)
 #define SCREENWIDTH 320
 //SCREEN_MUL*BASE_WIDTH //320
 #define SCREENHEIGHT 200
-//(int)(SCREEN_MUL*BASE_WIDTH*INV_ASPECT_RATIO) //200
+#endif // !defined(SCREENWIDTH) || !defined(SCREENHEIGHT)
+
+#if !defined(REFRESHRATE)
+// 0 means do not override the refresh rate
+// (use the default for the screen mode)
+// Only VESA modes are affected by this setting
+#define REFRESHRATE 0
+#endif // !defined(REFRESH)
+
+#if SCREENWIDTH == 320 && (SCREENHEIGHT == 200 || SCREENHEIGHT == 240)
+#define MulScreenWidth(x) Mul320(x)
+#define MulScreenWidthHalf(x) Mul160(x)
+#define MulScreenWidthQuarter(x) Mul80(x)
+#define MulScreenWidthEighth(x) Mul40(x)
+#if SCREENHEIGHT == 200
+#define ASPECTRATIO16x10
+#elif SCREENHEIGHT == 240
+#define ASPECTRATIO4x3
+#endif
+
+#elif SCREENWIDTH == 512 && SCREENHEIGHT == 384
+#define MulScreenWidth(x) Mul512(x)
+#define MulScreenWidthHalf(x) Mul256(x)
+#define MulScreenWidthQuarter(x) Mul128(x)
+#define MulScreenWidthEighth(x) Mul64(x)
+#define ASPECTRATIO4x3
+#define HI_RES
+#define PIXEL_SCALING 1
+
+#elif SCREENWIDTH == 640 && (SCREENHEIGHT == 400 || SCREENHEIGHT == 480)
+#define MulScreenWidth(x) Mul640(x)
+#define MulScreenWidthHalf(x) Mul320(x)
+#define MulScreenWidthQuarter(x) Mul160(x)
+#define MulScreenWidthEighth(x) Mul80(x)
+#define HI_RES
+#if SCREENHEIGHT == 400
+#define ASPECTRATIO16x10
+#elif SCREENHEIGHT == 480
+#define ASPECTRATIO4x3
+#endif
+
+#elif SCREENWIDTH == 800 && SCREENHEIGHT == 600
+#define MulScreenWidth(x) Mul800(x)
+#define MulScreenWidthHalf(x) Mul400(x)
+#define MulScreenWidthQuarter(x) Mul200(x)
+#define MulScreenWidthEighth(x) Mul100(x)
+#define ASPECTRATIO4x3
+#define HI_RES
+
+#elif SCREENWIDTH == 1024 && SCREENHEIGHT == 768
+#define MulScreenWidth(x) Mul1024(x)
+#define MulScreenWidthHalf(x) Mul512(x)
+#define MulScreenWidthQuarter(x) Mul256(x)
+#define MulScreenWidthEighth(x) Mul128(x)
+#define ASPECTRATIO4x3
+#define HI_RES
+
+#elif SCREENWIDTH == 1280 && SCREENHEIGHT == 1024
+#define MulScreenWidth(x) Mul1280(x)
+#define MulScreenWidthHalf(x) Mul640(x)
+#define MulScreenWidthQuarter(x) Mul320(x)
+#define MulScreenWidthEighth(x) Mul160(x)
+#define ASPECTRATIO5x4
+#define HI_RES
+#else
+#error "Defined Screen Resolution is not supported"
+#endif
+
+#ifdef HI_RES
+// By default we scale the screen by 2x to make it look better
+#ifndef PIXEL_SCALING
+#define PIXEL_SCALING 2
+#endif
+#else
+#define PIXEL_SCALING 1
+#endif
+#define SCALED_SCREENWIDTH (SCREENWIDTH / PIXEL_SCALING)
+#define SCALED_SCREENHEIGHT (SCREENHEIGHT / PIXEL_SCALING)
+#define SBARHEIGHT (32 * PIXEL_SCALING)
+#define SBARWIDTH (320 * PIXEL_SCALING)
+// Fcor screen resolution that don't scale perfectly, we need a centering
+// offset to make sure the menu/ui/etc. is centered on the screen.
+// Evertything is based on 320x200 which is the native positioning of
+// everything.
+// Note that this gets reduced to a constant at compile time
+#define CENTERING_OFFSET_X ((SCALED_SCREENWIDTH-320) / 2)
+#define CENTERING_OFFSET_Y ((SCALED_SCREENHEIGHT-200) / 2)
 
 // The maximum number of players, multiplayer/networking.
 #define MAXPLAYERS 4

--- a/FASTDOOM/doomdef.h
+++ b/FASTDOOM/doomdef.h
@@ -332,7 +332,8 @@ typedef enum
 
 typedef enum
 {
-    INTEL_386SX,
+    AUTO_CPU = -1,
+    INTEL_386SX = 0,
     INTEL_386DX,
     CYRIX_386DLC,
     CYRIX_486,

--- a/FASTDOOM/f_finale.c
+++ b/FASTDOOM/f_finale.c
@@ -367,12 +367,7 @@ void F_TextWrite(void)
 		w = hu_font[c]->width;
 		if (cx + w > SCREENWIDTH)
 			break;
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-		V_DrawPatchScreen0(cx, cy, hu_font[c]);
-#endif
-#if defined(USE_BACKBUFFER)
-		V_DrawPatchDirect(cx, cy, hu_font[c]);
-#endif
+    V_DrawPatchModeCentered(cy, cx, hu_font[c]);
 		cx += w;
 	}
 }
@@ -708,12 +703,7 @@ void F_CastPrint(char *text)
 		}
 
 		w = hu_font[c]->width;
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-		V_DrawPatchScreen0(cx, 180, hu_font[c]);
-#endif
-#if defined(USE_BACKBUFFER)
-		V_DrawPatchDirect(cx, 180, hu_font[c]);
-#endif
+    V_DrawPatchModeCentered(cx, 180, hu_font[c]);
 		cx += w;
 	}
 }
@@ -732,12 +722,7 @@ void F_CastDrawer(void)
 	patch_t *patch;
 
 // erase the entire screen to a background
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-	V_DrawPatchScreen0(0, 0, W_CacheLumpName("BOSSBACK", PU_CACHE));
-#endif
-#if defined(USE_BACKBUFFER)
-	V_DrawPatchDirect(0, 0, W_CacheLumpName("BOSSBACK", PU_CACHE));
-#endif
+  V_DrawPatchModeCentered(0, 0, W_CacheLumpName("BOSSBACK", PU_CACHE));
 
 	F_CastPrint(castorder[castnum].name);
 
@@ -750,21 +735,11 @@ void F_CastDrawer(void)
 	patch = W_CacheLumpNum(lump + firstspritelump, PU_CACHE);
 	if (flip)
 	{
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-		V_DrawPatchFlippedScreen0(160, 170, patch);
-#endif
-#if defined(USE_BACKBUFFER)
-		V_DrawPatchDirect(160, 170, patch);
-#endif
+    V_DrawPatchFlippedModeCentered(160, 170, patch);
 	}
 	else
 	{
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-		V_DrawPatchScreen0(160, 170, patch);
-#endif
-#if defined(USE_BACKBUFFER)
-		V_DrawPatchDirect(160, 170, patch);
-#endif
+    V_DrawPatchModeCentered(160, 170, patch);
 	}
 }
 #endif
@@ -859,7 +834,7 @@ void F_DrawPatchCol(int x, patch_t *patch, int col)
 	while (column->topdelta != 0xff)
 	{
 		source = (byte *)column + 3;
-		dest = desttop + Mul320(column->topdelta);
+		dest = desttop + MulScreenWidth(column->topdelta);
 		count = column->length;
 
 		while (count--)
@@ -1178,12 +1153,7 @@ void F_BunnyScroll(void)
 		return;
 	if (finalecount < 1180)
 	{
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-		V_DrawPatchScreen0((SCREENWIDTH - 13 * 8) / 2, (SCREENHEIGHT - 8 * 8) / 2, W_CacheLumpName("END0", PU_CACHE));
-#endif
-#if defined(USE_BACKBUFFER)
-		V_DrawPatchDirect((SCREENWIDTH - 13 * 8) / 2, (SCREENHEIGHT - 8 * 8) / 2, W_CacheLumpName("END0", PU_CACHE));
-#endif
+    V_DrawPatchModeCentered((SCALED_SCREENWIDTH - 13 * 8) / 2, (SCALED_SCREENHEIGHT - 8 * 8) / 2, W_CacheLumpName("END0", PU_CACHE), 0);
 		laststage = 0;
 		return;
 	}
@@ -1198,12 +1168,7 @@ void F_BunnyScroll(void)
 	}
 
 	sprintf(name, "END%i", stage);
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-	V_DrawPatchScreen0((SCREENWIDTH - 13 * 8) / 2, (SCREENHEIGHT - 8 * 8) / 2, W_CacheLumpName(name, PU_CACHE));
-#endif
-#if defined(USE_BACKBUFFER)
-	V_DrawPatchDirect((SCREENWIDTH - 13 * 8) / 2, (SCREENHEIGHT - 8 * 8) / 2, W_CacheLumpName(name, PU_CACHE));
-#endif
+  V_DrawPatchModeCentered((SCALED_SCREENWIDTH - 13 * 8) / 2, (SCALED_SCREENHEIGHT - 8 * 8) / 2, W_CacheLumpName(name, PU_CACHE));
 }
 #endif
 
@@ -1239,85 +1204,15 @@ void F_Drawer(void)
 		case 1:
 			if (gamemode == shareware)
 			{
-#if defined(MODE_T4025)
-				V_DrawPatchDirectText4025(0, 0, W_CacheLumpName("HELP2", PU_CACHE));
-#endif
-#if defined(MODE_T4050)
-				V_DrawPatchDirectText4050(0, 0, W_CacheLumpName("HELP2", PU_CACHE));
-#endif
-#if defined(MODE_T8025)
-				V_DrawPatchDirectText8025(0, 0, W_CacheLumpName("HELP2", PU_CACHE));
-#endif
-#if defined(MODE_MDA)
-				V_DrawPatchDirectTextMDA(0, 0, W_CacheLumpName("HELP2", PU_CACHE));
-#endif
-#if defined(MODE_T8043)
-				V_DrawPatchDirectText8043(0, 0, W_CacheLumpName("HELP2", PU_CACHE));
-#endif
-#if defined(MODE_T8050)
-				V_DrawPatchDirectText8050(0, 0, W_CacheLumpName("HELP2", PU_CACHE));
-#endif
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-				V_DrawPatchScreen0(0, 0, W_CacheLumpName("HELP2", PU_CACHE));
-#endif
-#if defined(USE_BACKBUFFER)
-				V_DrawPatchDirect(0, 0, W_CacheLumpName("HELP2", PU_CACHE));
-#endif
+        V_DrawPatchModeCentered(0, 0, W_CacheLumpName("HELP2", PU_CACHE), 0);
 			}
 			else
 			{
-#if defined(MODE_T4025)
-				V_DrawPatchDirectText4025(0, 0, W_CacheLumpName("CREDIT", PU_CACHE));
-#endif
-#if defined(MODE_T4050)
-				V_DrawPatchDirectText4050(0, 0, W_CacheLumpName("CREDIT", PU_CACHE));
-#endif
-#if defined(MODE_T8025)
-				V_DrawPatchDirectText8025(0, 0, W_CacheLumpName("CREDIT", PU_CACHE));
-#endif
-#if defined(MODE_MDA)
-				V_DrawPatchDirectTextMDA(0, 0, W_CacheLumpName("CREDIT", PU_CACHE));
-#endif
-#if defined(MODE_T8043)
-				V_DrawPatchDirectText8043(0, 0, W_CacheLumpName("CREDIT", PU_CACHE));
-#endif
-#if defined(MODE_T8050)
-				V_DrawPatchDirectText8050(0, 0, W_CacheLumpName("CREDIT", PU_CACHE));
-#endif
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-				V_DrawPatchScreen0(0, 0, W_CacheLumpName("CREDIT", PU_CACHE));
-#endif
-#if defined(USE_BACKBUFFER)
-				V_DrawPatchDirect(0, 0, W_CacheLumpName("CREDIT", PU_CACHE));
-#endif
+        V_DrawPatchModeCentered(0, 0, W_CacheLumpName("CREDIT", PU_CACHE), 0);
 			}
-
 			break;
 		case 2:
-#if defined(MODE_T4025)
-			V_DrawPatchDirectText4025(0, 0, W_CacheLumpName("VICTORY2", PU_CACHE));
-#endif
-#if defined(MODE_T4050)
-			V_DrawPatchDirectText4050(0, 0, W_CacheLumpName("VICTORY2", PU_CACHE));
-#endif
-#if defined(MODE_T8025)
-			V_DrawPatchDirectText8025(0, 0, W_CacheLumpName("VICTORY2", PU_CACHE));
-#endif
-#if defined(MODE_MDA)
-			V_DrawPatchDirectTextMDA(0, 0, W_CacheLumpName("VICTORY2", PU_CACHE));
-#endif
-#if defined(MODE_T8043)
-			V_DrawPatchDirectText8043(0, 0, W_CacheLumpName("VICTORY2", PU_CACHE));
-#endif
-#if defined(MODE_T8050)
-			V_DrawPatchDirectText8050(0, 0, W_CacheLumpName("VICTORY2", PU_CACHE));
-#endif
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-			V_DrawPatchScreen0(0, 0, W_CacheLumpName("VICTORY2", PU_CACHE));
-#endif
-#if defined(USE_BACKBUFFER)
-			V_DrawPatchDirect(0, 0, W_CacheLumpName("VICTORY2", PU_CACHE));
-#endif
+      V_DrawPatchModeCentered(0, 0, W_CacheLumpName("VICTORY2", PU_CACHE), 0);
 			break;
 		case 3:
 #if defined(MODE_Y) || defined(USE_BACKBUFFER) || defined(MODE_VBE2_DIRECT)
@@ -1328,30 +1223,7 @@ void F_Drawer(void)
 #endif
 			break;
 		case 4:
-#if defined(MODE_T4025)
-			V_DrawPatchDirectText4025(0, 0, W_CacheLumpName("ENDPIC", PU_CACHE));
-#endif
-#if defined(MODE_T4050)
-			V_DrawPatchDirectText4050(0, 0, W_CacheLumpName("ENDPIC", PU_CACHE));
-#endif
-#if defined(MODE_T8025)
-			V_DrawPatchDirectText8025(0, 0, W_CacheLumpName("ENDPIC", PU_CACHE));
-#endif
-#if defined(MODE_MDA)
-			V_DrawPatchDirectTextMDA(0, 0, W_CacheLumpName("ENDPIC", PU_CACHE));
-#endif
-#if defined(MODE_T8043)
-			V_DrawPatchDirectText8043(0, 0, W_CacheLumpName("ENDPIC", PU_CACHE));
-#endif
-#if defined(MODE_T8050)
-			V_DrawPatchDirectText8050(0, 0, W_CacheLumpName("ENDPIC", PU_CACHE));
-#endif
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-			V_DrawPatchScreen0(0, 0, W_CacheLumpName("ENDPIC", PU_CACHE));
-#endif
-#if defined(USE_BACKBUFFER)
-			V_DrawPatchDirect(0, 0, W_CacheLumpName("ENDPIC", PU_CACHE));
-#endif
+      V_DrawPatchModeCentered(0, 0, W_CacheLumpName("END0", PU_CACHE), 0);
 			break;
 		}
 	}

--- a/FASTDOOM/f_wipe.c
+++ b/FASTDOOM/f_wipe.c
@@ -52,32 +52,40 @@ static byte go = 0;
 byte *screen2;
 byte *screen3;
 
+
 void wipe_shittyColMajorXform(short *array)
 {
-    unsigned char y;
+    pixelcoord_t y;
     short *ptrarray = array;
     short *dest = (short *)Z_MallocUnowned(SCREENWIDTH * SCREENHEIGHT, PU_STATIC);
-
-    for (y = 0; y < SCREENHEIGHT; y++, dest -= 31999)
+    for (y = 0; y < SCREENHEIGHT; y++, dest -= ((SCREENHEIGHT * 8) * (SCREENWIDTH/16)) - 1)
     {
-        unsigned char x;
+        pixelcoord_t x;
 
-        for (x = 0; x < SCREENWIDTH / 16; x++, dest += 1600, ptrarray += 8)
+        for (x = 0; x < SCREENWIDTH / 16; x++, dest += (SCREENHEIGHT * 8), ptrarray += 8)
         {
             *dest = ptrarray[0];
-            *(dest + 200) = ptrarray[1];
-            *(dest + 400) = ptrarray[2];
-            *(dest + 600) = ptrarray[3];
-            *(dest + 800) = ptrarray[4];
-            *(dest + 1000) = ptrarray[5];
-            *(dest + 1200) = ptrarray[6];
-            *(dest + 1400) = ptrarray[7];
+            *(dest + SCREENHEIGHT) = ptrarray[1];
+            *(dest + SCREENHEIGHT * 2) = ptrarray[2];
+            *(dest + SCREENHEIGHT * 3) = ptrarray[3];
+            *(dest + SCREENHEIGHT * 4) = ptrarray[4];
+            *(dest + SCREENHEIGHT * 5) = ptrarray[5];
+            *(dest + SCREENHEIGHT * 6) = ptrarray[6];
+            *(dest + SCREENHEIGHT * 7) = ptrarray[7];
         }
     }
+    dest -= SCREENHEIGHT;
 
-    dest -= 200;
+    //The above implementation is equivalent to this, but presumably faster
+    /*
+    for(y = 0; y < SCREENHEIGHT; y++)
+    {
+        for(x = 0; x < SCREENWIDTH / 2; x++)
+        {
+            dest[x * SCREENHEIGHT + y] = ptrarray[x + y * SCREENWIDTH/2];
+        }
+    }*/
     CopyDWords(dest, array, (SCREENWIDTH * SCREENHEIGHT) / 4);
-
     Z_Free(dest);
 }
 
@@ -116,16 +124,17 @@ void wipe_initMelt()
 
 byte wipe_doMelt(int ticks)
 {
-    unsigned char i;
-    unsigned short i200;
+    int i;
+    unsigned int i_screen_height;
     byte done = 1;
 
     if (noMelt)
         return 1;
-
+    // This make it go about the same speed on all resolutions
+    ticks *= (SCREENHEIGHT / 200);
     while (ticks--)
     {
-        for (i = 0, i200 = 0; i < SCREENWIDTH / 2; i++, i200 += 200)
+        for (i = 0, i_screen_height = 0; i < SCREENWIDTH / 2; i++, i_screen_height += SCREENHEIGHT)
         {
             int y_val = y[i];
             if (y_val < 0)
@@ -142,12 +151,12 @@ byte wipe_doMelt(int ticks)
                 dy = (y_val < 16) ? y_val + 1 : 8;
                 if (dy >= SCREENHEIGHT - y_val)
                     dy = SCREENHEIGHT - y_val;
-                s = &((short *)screen3)[i200 + y_val];
+                s = &((short *)screen3)[i_screen_height + y_val];
                 #if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-                d = &((short *)screen0)[Mul160(y_val) + i];
+                d = &((short *)screen0)[MulScreenWidthHalf(y_val) + i];
                 #endif
                 #if defined(USE_BACKBUFFER)
-                d = &((short *)backbuffer)[Mul160(y_val) + i];
+                d = &((short *)backbuffer)[MulScreenWidthHalf(y_val) + i];
                 #endif
                 for (j = dy; j; j--)
                 {
@@ -155,12 +164,12 @@ byte wipe_doMelt(int ticks)
                     idx += SCREENWIDTH / 2;
                 }
                 y_val += dy;
-                s = &((short *)screen2)[i200];
+                s = &((short *)screen2)[i_screen_height];
                 #if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-                d = &((short *)screen0)[Mul160(y_val) + i];
+                d = &((short *)screen0)[MulScreenWidthHalf(y_val) + i];
                 #endif
                 #if defined(USE_BACKBUFFER)
-                d = &((short *)backbuffer)[Mul160(y_val) + i];
+                d = &((short *)backbuffer)[MulScreenWidthHalf(y_val) + i];
                 #endif
                 idx = 0;
                 for (j = SCREENHEIGHT - y_val; j; j--)

--- a/FASTDOOM/f_wipe.c
+++ b/FASTDOOM/f_wipe.c
@@ -28,6 +28,8 @@
 
 #include "doomdef.h"
 
+#include "i_debug.h"
+
 #include "f_wipe.h"
 
 #include <conio.h>

--- a/FASTDOOM/fastmath.h
+++ b/FASTDOOM/fastmath.h
@@ -87,6 +87,36 @@ int Mul320(int value);
     "lea eax, [eax+eax*4]", \
     "shl eax, 6" parm[eax] value[eax] modify exact[eax]
 
+int Mul640(int value);
+#pragma aux Mul640 = \
+    "lea eax, [eax+eax*4]", \
+    "shl eax, 7" parm[eax] value[eax] modify exact[eax]
+
+int Mul1280(int value);
+#pragma aux Mul1280 = \
+    "lea eax, [eax+eax*4]", \
+    "shl eax, 8" parm[eax] value[eax] modify exact[eax]
+
+int Mul64(int value);
+#pragma aux Mul64 = \
+    "shl eax, 6" parm[eax] value[eax] modify exact[eax]
+
+int Mul128(int value);
+#pragma aux Mul128 = \
+    "shl eax, 7" parm[eax] value[eax] modify exact[eax]
+
+int Mul256(int value);
+#pragma aux Mul256 = \
+    "shl eax, 8" parm[eax] value[eax] modify exact[eax]
+
+int Mul512(int value);
+#pragma aux Mul512 = \
+    "shl eax, 9" parm[eax] value[eax] modify exact[eax]
+
+int Mul1024(int value);
+#pragma aux Mul1024 = \
+    "shl eax, 10" parm[eax] value[eax] modify exact[eax]
+
 int Mul10(int value);
 #pragma aux Mul10 = \
     "lea eax, [eax+eax*4]", \
@@ -102,6 +132,24 @@ int Mul100(int value);
     "lea eax, [eax+eax*4]", \
     "lea eax, [eax+eax*4]", \
     "lea eax, [eax*4]" parm[eax] value[eax] modify exact[eax]
+
+int Mul200(int value);
+#pragma aux Mul200 = \
+    "lea eax, [eax+eax*4]", \
+    "lea eax, [eax+eax*4]", \
+    "shl eax, 3" parm[eax] value[eax] modify exact[eax]
+
+int Mul400(int value);
+#pragma aux Mul400 = \
+    "lea eax, [eax+eax*4]", \
+    "lea eax, [eax+eax*4]", \
+    "shl eax, 4" parm[eax] value[eax] modify exact[eax]
+
+int Mul800(int value);
+#pragma aux Mul800 = \
+    "lea eax, [eax+eax*4]", \
+    "lea eax, [eax+eax*4]", \
+    "shl eax, 5" parm[eax] value[eax] modify exact[eax]
 
 unsigned short USMul100(unsigned short value);
 #pragma aux USMul100 = \

--- a/FASTDOOM/fastmath.inc
+++ b/FASTDOOM/fastmath.inc
@@ -1,0 +1,74 @@
+
+%macro Mul320Start 2
+    lea %1, [%2+%2*4]
+%endmacro
+
+%macro Mul320End 1
+    shl %1, 6
+%endmacro
+
+%macro Mul640Start 2
+    lea %1, [%2+%2*4]
+%endmacro
+
+%macro Mul640End 1
+    shl %1, 7
+%endmacro
+
+%macro Mul1280Start 2
+    lea %1, [%2+%2*4]
+%endmacro
+
+%macro Mul1280End 1
+    shl %1, 8
+%endmacro
+
+%macro Mul256Start 2
+    mov %1, %2
+%endmacro
+
+%macro Mul256End 1
+    shl %1, 8
+%endmacro
+
+%macro Mul512Start 2
+    mov %1, %2
+%endmacro
+
+%macro Mul512End 1
+    shl %1, 9
+%endmacro
+
+%macro Mul1024Start 2
+    mov %1, %2
+%endmacro
+
+%macro Mul1024End 1
+    shl %1, 10
+%endmacro
+
+%macro Mul400Start 2
+    lea %1, [%2+%2*4]
+    lea %1, [%1+%1*4]
+%endmacro
+
+%macro Mul400End 1
+    shl %1, 4
+%endmacro
+
+%macro Mul800Start 2
+    lea %1, [%2+%2*4]
+    lea %1, [%1+%1*4]
+%endmacro
+
+%macro Mul800End 1
+    shl %1, 5
+%endmacro
+
+%macro MulStart 3
+    Mul%1Start %2, %3
+%endmacro
+
+%macro MulEnd 2
+    Mul%1End %2
+%endmacro

--- a/FASTDOOM/hu_lib.c
+++ b/FASTDOOM/hu_lib.c
@@ -156,11 +156,14 @@ void HUlib_eraseTextLine(hu_textline_t *l)
     if (!automapactive && viewwindowx && l->needsupdate)
 #endif
     {
+        // The text coordinates are in scaled pixels, so we need to
+        // scale them back to normal pixels for the erase.
         lh = l->f[0]->height + 1;
-        for (y = l->y, yoffset = Mul320(y); y < l->y + lh; y++, yoffset += SCREENWIDTH)
+        for (y = l->y * PIXEL_SCALING, yoffset = MulScreenWidth(y); y < (l->y + lh) * PIXEL_SCALING; y++, yoffset += SCREENWIDTH)
         {
-            if (y < viewwindowy || y >= viewwindowy + viewheight)
+            if (y < viewwindowy || y >= (viewwindowy + viewheight)) {
                 R_VideoErase(yoffset, SCREENWIDTH); // erase entire line
+            }
             else
             {
                 R_VideoErase(yoffset, viewwindowx);                           // erase left border

--- a/FASTDOOM/i_debug.c
+++ b/FASTDOOM/i_debug.c
@@ -1,20 +1,32 @@
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <dos.h>
+#include <stdarg.h>
+#include <conio.h>
 #include "doomtype.h"
 #include "fastmath.h"
 #include "options.h"
+#include "i_ibm.h"
+#include "i_system.h"
+#include "i_debug.h"
 
 #define COLOURS 0xFF
 #define COLS 80
 #define ROWS 25
 
-#define DEBUG_ENABLED 0
+
 
 #if (DEBUG_ENABLED == 1)
+
+int debug_to_screen = 0;
+
+void I_Putchar(byte c);
+
+#if (DEBUG_MDA_ENABLED == 1)
 unsigned short *Scrn = (unsigned short *)0xB0000;
 int Curx, Cury = 0;
 
-void I_Putchar(byte c);
 
 void I_Clear()
 {
@@ -43,8 +55,18 @@ void I_Scroll(void)
         Cury = ROWS - 1;
     }
 }
+
+void I_SetCursor(int x, int y) {
+    Curx = x;
+    Cury = y;
+}
+
+#endif
+
 void I_Putchar(byte c)
 {
+// Output to MDA text mode, if you're lucky enough to have one
+#if (DEBUG_MDA_ENABLED == 1)
     unsigned short *addr;
     if (c == '\t')
         Curx = ((Curx + 4) / 4) * 4;
@@ -70,6 +92,26 @@ void I_Putchar(byte c)
         Cury++;
     }
     I_Scroll();
+#endif // DEBUG_MDA_ENABLED
+    // This outputs to the bochs debug console, which is supported by dosbox-x
+    // with the config option 'bochs debug port e9 = true'
+#if (BOCHS_DEBUG_ENABLED == 1)
+    outp(0xE9, c);
+#endif // BOCHS_DEBUG_ENABLED
+    // This outputs to the serial port, which is all I have for real hardware
+#if (DEBUG_SERIAL_ENABLED == 1)
+    {
+      int status;
+      // Yuck, busy wait. Install an interrupt with DPMI?
+      do {
+        status = inp(DEBUG_SERIAL_BASE_IO + 5);
+      } while ((status & 0x20) == 0);
+      outp(DEBUG_SERIAL_BASE_IO, c);
+    }
+#endif
+    if (debug_to_screen) {
+        putchar(c);
+    }
 }
 
 void I_Puts(char *str)
@@ -100,6 +142,7 @@ void I_Printf(const char *format, ...)
             switch (c)
             {
             case 'd':
+            case 'i':
                 sprintf(buf, "%d", *((int *)arg++));
                 I_Puts(buf);
                 break;
@@ -137,8 +180,379 @@ void I_Printf(const char *format, ...)
     }
 }
 
-void I_SetCursor(int x, int y){
-    Curx = x;
-    Cury = y;
+static int FramePtr(void);
+#pragma aux FramePtr = "mov eax, ebp" value[eax];
+
+static int StackPtr(void);
+#pragma aux StackPtr = "mov eax, esp" value[eax];
+
+
+static void CleanupModules(debugmodule_t *modules, int num_modules) {
+    int i;
+    if (modules == NULL) {
+        return;
+    }
+    for (i = 0; i < num_modules; i++) {
+        free(modules[i].name);
+    }
+    free(modules);
 }
+
+static void CleanupSymbols(debugsymbol_t *symbols, int num_symbols) {
+    int i;
+    if (symbols == NULL) {
+        return;
+    }
+    for (i = 0; i < num_symbols; i++) {
+        free(symbols[i].name);
+    }
+    free(symbols);
+}
+
+#define MAX_MODULES 350
+#define MAX_SYMBOLS 3000
+
+void SortSymbols(debugsymbol_t *symbols, int num_symbols) {
+    if (num_symbols <= 1) {
+        return;
+    }
+    if (num_symbols == 2) {
+        if (symbols[0].addr > symbols[1].addr) {
+            debugsymbol_t tmp = symbols[0];
+            symbols[0] = symbols[1];
+            symbols[1] = tmp;
+        }
+        return;
+    } else {
+        int pivot = symbols[0].addr;
+        int left = 1;
+        int right = num_symbols - 1;
+        debugsymbol_t tmp;
+        while (left < right) {
+            while (left < right && symbols[left].addr < pivot) {
+                left++;
+            }
+            while (left < right && symbols[right].addr >= pivot) {
+                right--;
+            }
+            if (left < right) {
+                debugsymbol_t tmp = symbols[left];
+                symbols[left] = symbols[right];
+                symbols[right] = tmp;
+            }
+        }
+        if (symbols[left].addr >= pivot) {
+            left--;
+        }
+        tmp = symbols[0];
+        symbols[0] = symbols[left];
+        symbols[left] = tmp;
+        SortSymbols(symbols, left);
+        SortSymbols(symbols + left + 1, num_symbols - left - 1);
+    }
+}
+
+
+void DumpSymbolTable(debugsymbol_t *symbols, int num_symbols) {
+    int i;
+    if (symbols == NULL) {
+        return;
+    }
+    for (i = 0; i < num_symbols; i++) {
+        I_Printf("0x%x: %s\n", symbols[i].addr, symbols[i].name);
+    }
+}
+
+static void ReadMapFile(debugmodule_t **modules, int *num_modules, debugsymbol_t **symbols,
+                        int *num_symbols) {
+    char mapfile[256];
+    debugmodule_t *_modules = NULL;
+    int _num_modules = 0;
+    debugsymbol_t *_symbols = NULL;
+    int _num_symbols = 0;
+    extern char **__argv;
+    char line[512];
+    FILE *map;
+    debugmodule_t *current_module;
+    char *executable = __argv[0];
+    char *ext = strrchr(executable, '.');
+    if (ext) {
+        *ext = '\0';
+    }
+    sprintf(mapfile, "%s.map", executable);
+    map = fopen(mapfile, "r");
+    *ext = '.';
+    if (!map) {
+        I_Printf("Failed to open map file %s, symtable not available\n",
+                 mapfile);
+        return;
+    }
+    _modules = malloc(sizeof(debugmodule_t) * MAX_MODULES);
+    _symbols = malloc(sizeof(debugsymbol_t) * MAX_SYMBOLS);
+    if (modules == NULL || symbols == NULL) {
+        I_Printf("Failed to allocate memory for backtrace, symtable not "
+                 "available.\n");
+        goto fail;
+    }
+    // Read line by line
+    current_module = NULL;
+    while (fgets(line, sizeof(line), map) != NULL) {
+        if (strncmp(line, "Module: ", 8) == 0) {
+            char* obj_part = line + 8;
+            char *module_name;
+            // The module is formatted obj(source) but it's very long due to full
+            // paths. Let's drop the path
+            char* filepart = strrchr(obj_part, '(');
+            char* filepart_nopath;
+            char reformatted[256];
+            if (filepart) {
+                filepart[0] = '\0';
+                filepart++;
+                filepart_nopath = strrchr(filepart, '/');
+                if (filepart_nopath) {
+                    filepart = filepart_nopath + 1;
+                }
+                // Remove trailing '\n'
+                filepart[strlen(filepart) - 1] = '\0';
+            }
+            snprintf(reformatted, sizeof(reformatted), "%s(%s)", obj_part, filepart);
+            module_name = strdup(reformatted);
+            // Strip \n
+            if (!module_name) {
+                I_Printf("Failed to allocate memory for backtrace, symtable "
+                         "not available.\n");
+                goto fail;
+                return;
+            }
+            module_name[strlen(module_name) - 1] = '\0';
+            current_module = &_modules[_num_modules];
+            current_module->name = module_name;
+            _num_modules++;
+            if (_num_modules > MAX_MODULES) {
+                I_Printf("Too many modules, symtable incomplete, boost "
+                         "MAX_MODULES.\n");
+                goto cleanup;
+            }
+        } else if (strncmp(line, "0001:", 4) == 0 || strncmp(line, "0002:", 4) == 0) {
+            // Symbol
+            int addr = (int)strtol(line + 5, NULL, 16);
+            // Two chars whitespace
+            char *name = strdup(line + 5 + 10);
+            // Strip \n
+            debugsymbol_t *current_symbol = &_symbols[_num_symbols];
+            if (!name) {
+                I_Printf("Failed to allocate memory for backtrace, symtable "
+                         "not available.\n");
+                goto fail;
+            }
+            name[strlen(name) - 1] = '\0';
+            current_symbol->addr = addr;
+            current_symbol->name = name;
+            current_symbol->module = current_module;
+            if (_num_symbols > MAX_SYMBOLS) {
+                I_Printf("Too many symbols, symtable incomplete, boost "
+                         "MAX_SYMBOLS.\n");
+                goto cleanup;
+            }
+            _num_symbols++;
+        }
+    }
+    goto cleanup;
+fail:
+    CleanupModules(_modules, _num_modules);
+    CleanupSymbols(_symbols, _num_symbols);
+    _modules = NULL;
+    _symbols = NULL;
+    _num_modules = 0;
+    _num_symbols = 0;
+cleanup:
+    SortSymbols(_symbols, _num_symbols);
+    *modules = _modules;
+    *num_modules = _num_modules;
+    *symbols = _symbols;
+    *num_symbols = _num_symbols;
+    if (map) {
+        fclose(map);
+    }
+}
+
+static debugsymbol_t *LookupSymbol(debugsymbol_t *symbols, int num_symbols, int addr) {
+    int left = 0;
+    int right = num_symbols - 1;
+    int mid;
+    if (symbols == NULL || num_symbols == 0) {
+        return NULL;
+    }
+    // Binary search
+    while (left <= right) {
+        mid = (left + right) / 2;
+        if (symbols[mid].addr == addr) {
+            return &symbols[mid];
+        } else if (symbols[mid].addr < addr) {
+            left = mid + 1;
+        } else {
+            right = mid - 1;
+        }
+    }
+    if (symbols[left].addr < addr) {
+        return &symbols[left];
+    } else {
+        return &symbols[right];
+    }
+}
+
+// Global symbol table. Keep it hidden with static, only use module functions
+static debugmodule_t *modules = NULL;
+static debugsymbol_t *symbols = NULL;
+static int num_modules = 0;
+static int num_symbols = 0;
+
+extern char __begtext;
+#define TEXT_SECTION_START ((int)&__begtext - 3)
+
+debugsymbol_t* I_LookupSymbol(int addr) {
+    return LookupSymbol(symbols, num_symbols, addr - TEXT_SECTION_START);
+}
+
+const char *I_LookupSymbolName(void* addr) {
+    debugsymbol_t *symbol = LookupSymbol(symbols, num_symbols, (int)addr - TEXT_SECTION_START);
+    if (symbol) {
+        return symbol->name;
+    } else {
+        return NULL;
+    }
+}
+
+void I_DebugInit(void) {
+#if DEBUG_SERIAL_ENABLED==1
+    outp(DEBUG_SERIAL_BASE_IO + 1, 0x00); // Disable all interrupts
+    outp(DEBUG_SERIAL_BASE_IO + 3, 0x80); // Enable the baud rate divisor
+    outp(DEBUG_SERIAL_BASE_IO + 0, 115200 / DEBUG_SERIAL_BAUD); // Set the baud rate
+    outp(DEBUG_SERIAL_BASE_IO + 1, 0x00); // Hi byte
+    outp(DEBUG_SERIAL_BASE_IO + 3, 0x03); // 8 bits, no parity, one stop bit
+    I_Printf("Serial debug port initialized\n");
 #endif
+    I_Printf("Reading symbol table from map file\n");
+    ReadMapFile(&modules, &num_modules, &symbols, &num_symbols);
+    if (!modules) {
+        I_Printf("Failed to read symbol table\n");
+        return;
+    }
+    I_Printf("Symbol table ready, %i syms %i mods\n", num_symbols, num_modules);
+}
+
+void I_DebugShutdown(void) {
+    CleanupModules(modules, num_modules);
+    CleanupSymbols(symbols, num_symbols);
+    modules = NULL;
+    symbols = NULL;
+    num_modules = 0;
+    num_symbols = 0;
+}
+
+void I_ShutdownGraphics(void);
+
+#define MAX_BACKTRACE_FRAMES 25
+
+// Print a nice backtrace, reading from the .map file if it exists.
+void I_Backtrace(const char *msg, ...) {
+    extern char __begtext;
+    extern char ___Argc;
+    int text_end = (int)&___Argc;
+    int text_start = TEXT_SECTION_START;
+    int *stack = (int *)StackPtr();
+    int *frame = (int *)FramePtr();
+    int* backtrace_alloc[MAX_BACKTRACE_FRAMES + 1];
+    int* *backtrace = backtrace_alloc;
+    int num_backtrace = 0;
+
+    // If defined. pause the game, and print the backtrace to the screen
+#if (DEBUG_SHOW_BACKTRACE_ON_SCREEN == 1)
+    I_ShutdownGraphics();
+    I_ShutdownKeyboard();
+    debug_to_screen = 1;
+#endif
+    // What is the stack size? 0x10000?
+    if (frame < stack || frame > stack + 0x10000) {
+        I_Printf("Stack frames are omitted, backtrace is not possible. Make "
+                 "sure -of+ is set in compiler options for watcom\n");
+        return;
+    }
+    if (!modules) {
+        ReadMapFile(&modules, &num_modules, &symbols, &num_symbols);
+    }
+    // TODO Should we grab the registers here? Probably not needed
+    I_Printf("Backtrace EBP: 0x%x, ESP: 0x%x: TEXT: 0x%x", frame,
+             stack, text_start);
+    // Setup the backtrace buffer pointer
+    backtrace[MAX_BACKTRACE_FRAMES] = NULL;
+    // We put the most recent frame at the end of the buffer, so we need
+    // to walk backwards. We start at the end
+    backtrace = &backtrace[MAX_BACKTRACE_FRAMES];
+    // The frame is the EBP register, which points to the previous frame
+    while (frame != NULL) {
+        // THe return pointer is the second thing on the stack frame
+        int *retptr = frame + 1;
+        // Does the return pointer make seense?
+        if (*retptr > text_start && *retptr < text_end) {
+          // Record the frame if we have space
+          if (num_backtrace >= MAX_BACKTRACE_FRAMES) {
+              I_Printf("Notice: backtrace is truncated\n");
+              break;
+          }
+          backtrace--;
+          *backtrace = retptr;
+          num_backtrace++;
+          // Next
+        } else {
+            break;
+        }
+        // The next frame is the previous EBP, or the first thing on the stack
+        // frame. This forms a linked list
+        frame = (int *)frame[0];
+        if (frame[0] <= frame) {
+            // This is a nonsense frame, abort
+            break;
+        }
+    }
+    while(*backtrace) {
+        int* retptr = *backtrace;
+        int offset_in_text = *retptr - text_start;
+        // Try to lookup the symbol info
+        debugsymbol_t *symbol = LookupSymbol(symbols, num_symbols, offset_in_text);
+        if (symbol) {
+          I_Printf("  0x%x[text+0x%x] %s+%x %s \n", *retptr,
+                   offset_in_text, symbol->name, offset_in_text - symbol->addr,
+                   symbol->module->name);
+        } else {
+            I_Printf("  0x%x[text+0x%x] \n", *retptr,
+                     offset_in_text);
+        }
+        backtrace++;
+    }
+    {
+      char msgbuf[256];
+      va_list args;
+      va_start(args, msg);
+      vsnprintf(msgbuf, sizeof(msgbuf), msg, args);
+      va_end(args);
+      I_Puts(msgbuf);
+    }
+#if (DEBUG_DIE_ON_BACKTRACE == 1)
+    exit(1);
+#elif (DEBUG_SHOW_BACKTRACE_ON_SCREEN == 1)
+    printf("Press any key to continue, ESC to quit\n");
+    {
+      // TODO this isn't always reliable
+      char c = getchar();
+      if (c == 27) {
+          exit(1);
+      }
+      debug_to_screen = 0;
+      I_InitGraphics();
+      I_StartupKeyboard();
+    }
+#endif
+}
+
+#endif // DEBUG_ENABLED

--- a/FASTDOOM/i_debug.h
+++ b/FASTDOOM/i_debug.h
@@ -1,5 +1,66 @@
+#ifndef __I_DEBUG_H__
+#define __I_DEBUG_H__
 #include "fastmath.h"
+#include "i_system.h"
+
+// DEBUG_ENABLED is set by the build.sh
+
+#if (DEBUG_ENABLED == 1)
+#include "dbgcfg.h"
+#ifdef DEBUG_UNCONFIGURED
+#error "DEBUG_ENABLED is set but debugging is not configured in dbgcfg.h"
+#endif
+#endif // DEBUG_ENABLED
 
 void I_Printf(const char *format, ...);
 void I_SetCursor(int x, int y);
 void I_Clear();
+void I_DebugInit();
+
+typedef struct debugmodule_t {
+    const char *name;
+} debugmodule_t;
+
+typedef struct debugsymbol_t {
+    int addr;
+    const char *name;
+    debugmodule_t *module;
+    int is_data;
+} debugsymbol_t;
+
+debugsymbol_t *I_LookupSymbol(int addr);
+
+const char* I_LookupSymbolName(void* addr);
+
+void I_Backtrace(const char *msg, ...);
+
+void I_DebugShutdown(void);
+
+
+#if BOUNDS_CHECK_ENABLED == 1
+#define BOUNDS_CHECK(x, y)                                                     \
+    if ((unsigned)(x) >= SCREENWIDTH || (unsigned)(y) >= SCREENHEIGHT) {       \
+      I_Backtrace("Bounds check failure at %s:%i, X:%i Y:%i\n", __FILE__,      \
+                  __LINE__, x, y);                                             \
+    }
+#define SCALED_BOUNDS_CHECK(x, y)                                              \
+    if ((unsigned)(x) >= SCALED_SCREENWIDTH ||                                 \
+        (unsigned)(y) >= SCALED_SCREENHEIGHT) {                                \
+      I_Backtrace("Scaled bounds check failure at %s::%i X:%i Y:%i\n",         \
+                  __FILE__, __LINE__, x, y);                                   \
+    }
+#else
+#define BOUNDS_CHECK(x, y)
+#define SCALED_BOUNDS_CHECK(x, y)
+#endif
+
+#if ASSERT_ENABLED == 1
+#define ASSERT(x)                                                              \
+    if (!(x)) {                                                                \
+      I_Backtrace("Assertion failure at %s:%i\n", __FILE__, __LINE__);         \
+    }
+#else
+#define ASSERT(x) do {} while(0)
+#endif
+
+#endif // __I_DEBUG_H__

--- a/FASTDOOM/i_ibm.c
+++ b/FASTDOOM/i_ibm.c
@@ -127,7 +127,6 @@
 //
 
 #define DPMI_INT 0x31
-#define SBARHEIGHT 32
 
 //
 // Code
@@ -283,7 +282,7 @@ void I_UpdateBox(int x, int y, int w, int h)
     byte *dest;
     byte *source;
     int i;
-    int offset = Mul320(y) + x;
+    int offset = MulScreenWidth(y) + x;
 
     dest = destscreen + offset;
     source = screen0 + offset;
@@ -293,8 +292,8 @@ void I_UpdateBox(int x, int y, int w, int h)
         for (i = y; i < y + h; i++)
         {
             CopyBytes(source, dest, w);
-            dest += 320;
-            source += 320;
+            dest += SCREENWIDTH;
+            source += SCREENWIDTH;
         }
     }
     else
@@ -304,8 +303,8 @@ void I_UpdateBox(int x, int y, int w, int h)
         for (i = y; i < y + h; i++)
         {
             CopyWords(source, dest, w);
-            dest += 320;
-            source += 320;
+            dest += SCREENWIDTH;
+            source += SCREENWIDTH;
         }
     }
 }
@@ -315,7 +314,7 @@ void I_UpdateBoxTransparent(int x, int y, int w, int h)
     byte *dest;
     byte *source;
     int i;
-    int offset = Mul320(y) + x;
+    int offset = MulScreenWidth(y) + x;
 
     dest = destscreen + offset;
     source = screen0 + offset;
@@ -330,8 +329,8 @@ void I_UpdateBoxTransparent(int x, int y, int w, int h)
             }
         }
 
-        dest += 320;
-        source += 320;
+        dest += SCREENWIDTH;
+        source += SCREENWIDTH;
     }
 }
 #endif
@@ -351,7 +350,7 @@ void I_UpdateBox(int x, int y, int w, int h)
     sp_x2 = (x + w) / 8;
     count = sp_x2 - sp_x1 + 1;
     step = SCREENWIDTH - count * 8;
-    offset = Mul320(y) + sp_x1 * 8;
+    offset = MulScreenWidth(y) + sp_x1 * 8;
     poffset = offset / 4;
     pstep = step / 4;
 
@@ -427,7 +426,7 @@ void I_UpdateBoxTransparent(int x, int y, int w, int h)
     sp_x2 = (x + w) / 8;
     count = sp_x2 - sp_x1 + 1;
     step = SCREENWIDTH - count * 8;
-    offset = Mul320(y) + sp_x1 * 8;
+    offset = MulScreenWidth(y) + sp_x1 * 8;
     poffset = offset / 4;
     pstep = step / 4;
 

--- a/FASTDOOM/i_vga13h.c
+++ b/FASTDOOM/i_vga13h.c
@@ -15,17 +15,16 @@
 #include "m_menu.h"
 #include "i_vga13h.h"
 
-#define SBARHEIGHT 32
 
 #if defined(MODE_13H)
 
 void (*finishfunc)(void);
 
-extern byte vrambuffer[320*200];
+extern byte vrambuffer[SCREENWIDTH*SCREENHEIGHT];
 
 void I_CleanupVRAMbuffer(void)
 {
-    SetDWords(vrambuffer, 0, 320 * 200 / 4);
+    SetDWords(vrambuffer, 0, SCREENWIDTH * SCREENHEIGHT / 4);
 }
 
 void I_UpdateFinishFunc(void)

--- a/FASTDOOM/i_vgay.c
+++ b/FASTDOOM/i_vgay.c
@@ -22,7 +22,6 @@
 #define CRTC_MODE 23
 #define GC_READMAP 4
 
-#define SBARHEIGHT 32
 
 #if defined(MODE_Y)
 

--- a/FASTDOOM/linearh.asm
+++ b/FASTDOOM/linearh.asm
@@ -221,7 +221,7 @@ CODE_SYM_DEF R_DrawSpanBackbuffer
   %assign PLANE 0
     MAPLABEL LINE:
       %assign LINE LINE+1
-      %if LINE = 320
+      %if LINE = SCREENWIDTH
         mov   al,[esi+ebx]           ; get source pixel
         mov   al,[eax]               ; translate color
         mov   [edi+PLANE+PCOL],al  ; write pixel
@@ -238,6 +238,7 @@ CODE_SYM_DEF R_DrawSpanBackbuffer
 %assign PCOL PCOL+1
 %endrep
 
-hmap320: ret
+MAPLABEL LINE:
+  ret
 
 %endif

--- a/FASTDOOM/linearh2.asm
+++ b/FASTDOOM/linearh2.asm
@@ -122,13 +122,13 @@ CODE_SYM_DEF R_DrawFuzzColumnBackbuffer
 %rep SCREENHEIGHT
   SCALELABEL LINE:
   mov		ebp,[edx+ecx*4]
-	mov   al,[ebp+edi-(LINE-1)*320]
+	mov   al,[ebp+edi-(LINE-1)*SCREENWIDTH]
   dec   ecx
 	mov		al,[eax]
   JMPTESTFUZZPOSDEFINE LINE
   mov   ecx,ebx
   TESTFUZZPOSDEFINE LINE:
-  mov		[edi-(LINE-1)*320],al
+  mov		[edi-(LINE-1)*SCREENWIDTH],al
   %assign LINE LINE-1
 %endrep
 

--- a/FASTDOOM/linearh3.asm
+++ b/FASTDOOM/linearh3.asm
@@ -99,20 +99,20 @@ CODE_SYM_DEF R_DrawFuzzColumnFlatBackbuffer
 %rep SCREENHEIGHT-1
   SCALELABEL LINE:
 
-	mov   al,[edi-(LINE-1)*320]
+	mov   al,[edi-(LINE-1)*SCREENWIDTH]
 	mov		al,[eax]
-  mov		[edi-(LINE-1)*320],al
+  mov		[edi-(LINE-1)*SCREENWIDTH],al
 
   %assign LINE LINE-1
 %endrep
 
 vscale1:
 
-  mov   al,[edi-(LINE-1)*320]
+  mov   al,[edi-(LINE-1)*SCREENWIDTH]
 	pop	ebp
 	mov		al,[eax]
   pop	esi
-  mov		[edi-(LINE-1)*320],al
+  mov		[edi-(LINE-1)*SCREENWIDTH],al
   pop	edx
 
 vscale0:

--- a/FASTDOOM/linearhSX.asm
+++ b/FASTDOOM/linearhSX.asm
@@ -112,7 +112,7 @@ CODE_SYM_DEF R_DrawSpanBackbuffer386SX
   %assign PLANE 0
     MAPLABEL LINE:
       %assign LINE LINE+1
-      %if LINE = 320
+      %if LINE = SCREENWIDTH
         mov   al,[esi+ebx]           ; get source pixel
         mov   al,[eax]               ; translate color
         mov   [edi+PLANE+PCOL],al  ; write pixel
@@ -129,6 +129,6 @@ CODE_SYM_DEF R_DrawSpanBackbuffer386SX
 %assign PCOL PCOL+1
 %endrep
 
-hmap320: ret
+MAPLABEL LINE: ret
 
 %endif

--- a/FASTDOOM/linearl.asm
+++ b/FASTDOOM/linearl.asm
@@ -224,7 +224,7 @@ CODE_SYM_DEF R_DrawSpanLowBackbuffer
   %assign PLANE 0
     MAPLABEL LINE:
       %assign LINE LINE+1
-      %if LINE = 160
+      %if LINE = SCREENWIDTH/2
         mov   al,[esi+ebx]           ; get source pixel
         mov   dl,[eax]               ; translate color
         mov   dh,dl
@@ -243,7 +243,7 @@ CODE_SYM_DEF R_DrawSpanLowBackbuffer
 %assign PCOL PCOL+1
 %endrep
 
-hmap160: 
+MAPLABEL LINE:
   ret
 
 %endif

--- a/FASTDOOM/linearl2.asm
+++ b/FASTDOOM/linearl2.asm
@@ -123,14 +123,14 @@ CODE_SYM_DEF R_DrawFuzzColumnLowBackbuffer
 %rep SCREENHEIGHT
   SCALELABEL LINE:
   mov		ebp,[edx+ecx*4]
-	mov   al,[ebp+edi-(LINE-1)*320]
+	mov   al,[ebp+edi-(LINE-1)*SCREENWIDTH]
   dec   ecx
 	mov		bl,[eax]
   JMPTESTFUZZPOSDEFINE LINE
   mov   ecx,esi
   TESTFUZZPOSDEFINE LINE:
   mov   bh,bl
-  mov		[edi-(LINE-1)*320],bx
+  mov		[edi-(LINE-1)*SCREENWIDTH],bx
   %assign LINE LINE-1
 %endrep
 

--- a/FASTDOOM/linearl3.asm
+++ b/FASTDOOM/linearl3.asm
@@ -101,23 +101,23 @@ CODE_SYM_DEF R_DrawFuzzColumnFlatLowBackbuffer
 %rep SCREENHEIGHT-1
   SCALELABEL LINE:
 
-	mov   al,[edi-(LINE-1)*320]
+	mov   al,[edi-(LINE-1)*SCREENWIDTH]
 	mov		cl,[eax]
   mov   ch,cl
-  mov		[edi-(LINE-1)*320],cx
+  mov		[edi-(LINE-1)*SCREENWIDTH],cx
 
   %assign LINE LINE-1
 %endrep
 
 vscale1:
 
-  mov   al,[edi-(LINE-1)*320]
+  mov   al,[edi-(LINE-1)*SCREENWIDTH]
 	pop	ebp
 	mov		cl,[eax]
   pop	esi
   mov   ch,cl
   pop	edx
-  mov		[edi-(LINE-1)*320],cx
+  mov		[edi-(LINE-1)*SCREENWIDTH],cx
 
 vscale0:
 	pop	ecx

--- a/FASTDOOM/linearlSX.asm
+++ b/FASTDOOM/linearlSX.asm
@@ -113,7 +113,7 @@ CODE_SYM_DEF R_DrawSpanLowBackbuffer386SX
   %assign PLANE 0
     MAPLABEL LINE:
       %assign LINE LINE+1
-      %if LINE = 160
+      %if LINE = SCREENWIDTH/2
         mov   al,[esi+ebx]           ; get source pixel
         mov   dl,[eax]               ; translate color
         mov   dh,dl
@@ -132,7 +132,7 @@ CODE_SYM_DEF R_DrawSpanLowBackbuffer386SX
 %assign PCOL PCOL+1
 %endrep
 
-hmap160: 
+MAPLABEL LINE:
   ret
 
 %endif

--- a/FASTDOOM/linearp.asm
+++ b/FASTDOOM/linearp.asm
@@ -247,6 +247,6 @@ CODE_SYM_DEF R_DrawSpanPotatoBackbuffer
 %assign PCOL PCOL+1
 %endrep
 
-hmap80: ret
+MAPLABEL LINE: ret
 
 %endif

--- a/FASTDOOM/linearp2.asm
+++ b/FASTDOOM/linearp2.asm
@@ -123,15 +123,15 @@ CODE_SYM_DEF R_DrawFuzzColumnPotatoBackbuffer
 %rep SCREENHEIGHT
   SCALELABEL LINE:
   mov		ebp,[edx+ecx*4]
-	mov   al,[ebp+edi-(LINE-1)*320]
+	mov   al,[ebp+edi-(LINE-1)*SCREENWIDTH]
   dec   ecx
 	mov		bl,[eax]
   JMPTESTFUZZPOSDEFINE LINE
   mov   ecx,esi
   TESTFUZZPOSDEFINE LINE:
   mov   bh,bl
-  mov		[edi-(LINE-1)*320],bx
-  mov		[edi-(LINE-1)*320+2],bx
+  mov		[edi-(LINE-1)*SCREENWIDTH],bx
+  mov		[edi-(LINE-1)*SCREENWIDTH+2],bx
   %assign LINE LINE-1
 %endrep
 

--- a/FASTDOOM/linearp3.asm
+++ b/FASTDOOM/linearp3.asm
@@ -101,26 +101,26 @@ CODE_SYM_DEF R_DrawFuzzColumnFlatPotatoBackbuffer
 %rep SCREENHEIGHT-1
   SCALELABEL LINE:
 
-	mov   al,[edi-(LINE-1)*320]
+	mov   al,[edi-(LINE-1)*SCREENWIDTH]
 	mov		cl,[eax]
   mov   ch,cl
-  mov		[edi-(LINE-1)*320],cx
-  mov		[edi-(LINE-1)*320+2],cx
+  mov		[edi-(LINE-1)*SCREENWIDTH],cx
+  mov		[edi-(LINE-1)*SCREENWIDTH+2],cx
 
   %assign LINE LINE-1
 %endrep
 
 vscale1:
 
-  mov   al,[edi-(LINE-1)*320]
+  mov   al,[edi-(LINE-1)*SCREENWIDTH]
 	pop	ebp
 	mov		cl,[eax]
   pop	esi
   mov   ch,cl
   pop	edx
-  mov		[edi-(LINE-1)*320],cx
-  mov		[edi-(LINE-1)*320+2],cx
-  
+  mov		[edi-(LINE-1)*SCREENWIDTH],cx
+  mov		[edi-(LINE-1)*SCREENWIDTH+2],cx
+
 vscale0:
 	pop	ecx
 	pop	ebx

--- a/FASTDOOM/linearpSX.asm
+++ b/FASTDOOM/linearpSX.asm
@@ -113,7 +113,7 @@ CODE_SYM_DEF R_DrawSpanPotatoBackbuffer386SX
   %assign PLANE 0
     MAPLABEL LINE:
       %assign LINE LINE+1
-      %if LINE = 80
+      %if LINE = SCREENWIDTH/4
         mov   al,[esi+ebx]           ; get source pixel
         mov   dl,[eax]               ; translate color
         mov   dh,dl
@@ -125,7 +125,7 @@ CODE_SYM_DEF R_DrawSpanPotatoBackbuffer386SX
         mov   dl,[eax]               ; translate color
         shld  ebx,ecx,6              ; shift x units in
         mov   dh,dl
-        mov   [edi+PLANE+PCOL*4],dx  ; write pixel        
+        mov   [edi+PLANE+PCOL*4],dx  ; write pixel
         mov   [edi+PLANE+PCOL*4+2],dx  ; write pixel
         and   ebx,0x0FFF             ; mask off slop bits
         add   ecx,ebp                ; position += step
@@ -134,6 +134,6 @@ CODE_SYM_DEF R_DrawSpanPotatoBackbuffer386SX
 %assign PCOL PCOL+1
 %endrep
 
-hmap80: ret
+MAPLABEL LINE: ret
 
 %endif

--- a/FASTDOOM/m_menu.c
+++ b/FASTDOOM/m_menu.c
@@ -1690,6 +1690,9 @@ void M_DrawDisplay(void)
     M_WriteText(58, 156, "CPU RENDERER:");
     switch (selectedCPU)
     {
+    case AUTO_CPU:
+        M_WriteText(214, 156, "AUTODETECT");
+        break;
     case INTEL_386SX:
         M_WriteText(214, 156, "INTEL 386SX");
         break;

--- a/FASTDOOM/m_menu.c
+++ b/FASTDOOM/m_menu.c
@@ -191,7 +191,7 @@ void M_ChooseSkill(int choice);
 void M_LoadGame(int choice);
 void M_SaveGame(int choice);
 void M_Options(int choice);
-void M_EndGame(int choice); 
+void M_EndGame(int choice);
 void M_QuitDOOM(int choice);
 
 void M_ChangeMessages(int choice);
@@ -567,7 +567,7 @@ void M_DrawLoad(void)
     V_WriteTextDirect(18, 7, "LOAD GAME");
 #endif
 #if defined(MODE_Y) || defined(USE_BACKBUFFER) || defined(MODE_VBE2_DIRECT)
-    V_DrawPatchDirect(72, 28, W_CacheLumpName("M_LOADG", PU_CACHE));
+    V_DrawPatchDirectCentered(72, 28, W_CacheLumpName("M_LOADG", PU_CACHE));
 #endif
 
     for (i = 0; i < load_end; i++)
@@ -608,15 +608,15 @@ void M_DrawSaveLoadBorder(int x, int y)
 {
     int i;
 
-    V_DrawPatchDirect(x - 8, y + 7, W_CacheLumpName("M_LSLEFT", PU_CACHE));
+    V_DrawPatchDirectCentered(x - 8, y + 7, W_CacheLumpName("M_LSLEFT", PU_CACHE));
 
     for (i = 0; i < 24; i++)
     {
-        V_DrawPatchDirect(x, y + 7, W_CacheLumpName("M_LSCNTR", PU_CACHE));
+        V_DrawPatchDirectCentered(x, y + 7, W_CacheLumpName("M_LSCNTR", PU_CACHE));
         x += 8;
     }
 
-    V_DrawPatchDirect(x, y + 7, W_CacheLumpName("M_LSRGHT", PU_CACHE));
+    V_DrawPatchDirectCentered(x, y + 7, W_CacheLumpName("M_LSRGHT", PU_CACHE));
 }
 #endif
 
@@ -684,7 +684,7 @@ void M_DrawSave(void)
     V_WriteTextDirect(18, 7, "SAVE GAME");
 #endif
 #if defined(MODE_Y) || defined(USE_BACKBUFFER) || defined(MODE_VBE2_DIRECT)
-    V_DrawPatchDirect(72, 28, W_CacheLumpName("M_SAVEG", PU_CACHE));
+    V_DrawPatchDirectCentered(72, 28, W_CacheLumpName("M_SAVEG", PU_CACHE));
 #endif
 
     for (i = 0; i < load_end; i++)
@@ -873,7 +873,7 @@ void M_DrawSound(void)
     V_WriteTextDirect(40, 32, monoSound ? "ON" : "OFF");
 #endif
 #if defined(MODE_Y) || defined(USE_BACKBUFFER) || defined(MODE_VBE2_DIRECT)
-    V_DrawPatchDirect(60, 38, W_CacheLumpName("M_SVOL", PU_CACHE));
+    V_DrawPatchDirectCentered(60, 38, W_CacheLumpName("M_SVOL", PU_CACHE));
 
     M_DrawThermo(SoundDef.x, SoundDef.y + LINEHEIGHT * (sfx_vol + 1), 16, sfxVolume);
     M_DrawThermo(SoundDef.x, SoundDef.y + LINEHEIGHT * (music_vol + 1), 16, musicVolume);
@@ -1101,7 +1101,7 @@ void M_BenchmarkRunDemo(void)
 
         // Alloc memory for frametimes
         frametime = (unsigned int *)Z_MallocUnowned(benchmark_total_tics * sizeof(unsigned int), PU_STATIC);
-            
+
         for (i = 0; i < benchmark_total_tics; i++)
         {
             frametime[i] = 0;
@@ -1193,7 +1193,7 @@ void M_DrawMainMenu(void)
     V_WriteTextDirect(23, 10, "DOOM");
 #endif
 #if defined(MODE_Y) || defined(USE_BACKBUFFER) || defined(MODE_VBE2_DIRECT)
-    V_DrawPatchDirect(94, 2, W_CacheLumpName("M_DOOM", PU_CACHE));
+    V_DrawPatchDirectCentered(94, 2, W_CacheLumpName("M_DOOM", PU_CACHE));
 #endif
 }
 
@@ -1215,8 +1215,8 @@ void M_DrawNewGame(void)
     V_WriteTextDirect(13, 9, "Choose skill level:");
 #endif
 #if defined(MODE_Y) || defined(USE_BACKBUFFER) || defined(MODE_VBE2_DIRECT)
-    V_DrawPatchDirect(96, 14, W_CacheLumpName("M_NEWG", PU_CACHE));
-    V_DrawPatchDirect(54, 38, W_CacheLumpName("M_SKILL", PU_CACHE));
+    V_DrawPatchDirectCentered(96, 14, W_CacheLumpName("M_NEWG", PU_CACHE));
+    V_DrawPatchDirectCentered(54, 38, W_CacheLumpName("M_SKILL", PU_CACHE));
 #endif
 }
 
@@ -1245,7 +1245,7 @@ void M_DrawEpisode(void)
     V_WriteTextDirect(27, 9, "WHICH EPISODE?");
 #endif
 #if defined(MODE_Y) || defined(USE_BACKBUFFER) || defined(MODE_VBE2_DIRECT)
-    V_DrawPatchDirect(54, 38, W_CacheLumpName("M_EPISOD", PU_CACHE));
+    V_DrawPatchDirectCentered(54, 38, W_CacheLumpName("M_EPISOD", PU_CACHE));
 #endif
 }
 
@@ -1311,8 +1311,8 @@ void M_DrawOptions(void)
     V_WriteTextDirect(15, 38, "Benchmark");
 #endif
 #if defined(MODE_Y) || defined(USE_BACKBUFFER) || defined(MODE_VBE2_DIRECT)
-    V_DrawPatchDirect(108, 2, W_CacheLumpName("M_OPTTTL", PU_CACHE));
-    V_DrawPatchDirect(OptionsDef.x + 120, OptionsDef.y + LINEHEIGHT * messages, W_CacheLumpName((char *)msgNames[showMessages], PU_CACHE));
+    V_DrawPatchDirectCentered(108, 2, W_CacheLumpName("M_OPTTTL", PU_CACHE));
+    V_DrawPatchDirectCentered(OptionsDef.x + 120, OptionsDef.y + LINEHEIGHT * messages, W_CacheLumpName((char *)msgNames[showMessages], PU_CACHE));
     M_DrawThermo(OptionsDef.x, OptionsDef.y + LINEHEIGHT * (mousesens + 1), 10, mouseSensitivity);
     M_DrawThermo(OptionsDef.x, OptionsDef.y + LINEHEIGHT * (scrnsize + 1), 10, screenSize);
     M_WriteText(OptionsDef.x + 1, OptionsDef.y + LINEHEIGHT * benchmark_option + 4, "BENCHMARK");
@@ -1321,7 +1321,7 @@ void M_DrawOptions(void)
 
 void M_DrawDisplay(void)
 {
-    // V_DrawPatchDirect(54, 15, 0, W_CacheLumpName("M_DISOPT", PU_CACHE));
+    // V_DrawPatchDirectCentered(54, 15, 0, W_CacheLumpName("M_DISOPT", PU_CACHE));
 
 #if defined(MODE_T4025) || defined(MODE_T4050)
     V_WriteTextDirect(6, 1, "VSync:");
@@ -2137,18 +2137,17 @@ void M_DrawThermo(int x, int y, int thermWidth, int thermDot)
 {
     int xx;
     int i;
-
     xx = x;
-    V_DrawPatchDirect(xx, y, W_CacheLumpName("M_THERML", PU_CACHE));
+    V_DrawPatchDirectCentered(xx, y, W_CacheLumpName("M_THERML", PU_CACHE));
     xx += 8;
     for (i = 0; i < thermWidth; i++)
     {
-        V_DrawPatchDirect(xx, y, W_CacheLumpName("M_THERMM", PU_CACHE));
+        V_DrawPatchDirectCentered(xx, y, W_CacheLumpName("M_THERMM", PU_CACHE));
         xx += 8;
     }
-    V_DrawPatchDirect(xx, y, W_CacheLumpName("M_THERMR", PU_CACHE));
+    V_DrawPatchDirectCentered(xx, y, W_CacheLumpName("M_THERMR", PU_CACHE));
 
-    V_DrawPatchDirect((x + 8) + thermDot * 8, y, W_CacheLumpName("M_THERMO", PU_CACHE));
+    V_DrawPatchDirectCentered((x + 8) + thermDot * 8, y, W_CacheLumpName("M_THERMO", PU_CACHE));
 }
 #endif
 
@@ -2271,7 +2270,7 @@ void M_WriteText(int x, int y, char *string)
         w = hu_font[c]->width;
         if (cx + w > SCREENWIDTH)
             break;
-        V_DrawPatchDirect(cx, cy, hu_font[c]);
+        V_DrawPatchDirectCentered(cx, cy, hu_font[c]);
         cx += w;
     }
 }
@@ -2717,7 +2716,7 @@ void M_Drawer(void)
             V_WriteTextDirect(x / 4, y / 4, currentMenu->menuitems[i].text);
 #endif
 #if defined(MODE_Y) || defined(USE_BACKBUFFER) || defined(MODE_VBE2_DIRECT)
-            V_DrawPatchDirect(x, y, W_CacheLumpName(currentMenu->menuitems[i].name, PU_CACHE));
+            V_DrawPatchDirectCentered(x,  y, W_CacheLumpName(currentMenu->menuitems[i].name, PU_CACHE));
 #endif
         }
 
@@ -2735,7 +2734,7 @@ void M_Drawer(void)
     V_WriteCharDirect(currentMenu->x / 4 - 3, currentMenu->y / 4 + itemOn * 4, whichSkull + 1);
 #endif
 #if defined(MODE_Y) || defined(USE_BACKBUFFER) || defined(MODE_VBE2_DIRECT)
-    V_DrawPatchDirect(x + SKULLXOFF, currentMenu->y - 5 + itemOn * LINEHEIGHT, W_CacheLumpName(skullName[whichSkull], PU_CACHE));
+    V_DrawPatchDirectCentered(x + SKULLXOFF, currentMenu->y - 5 + itemOn * LINEHEIGHT, W_CacheLumpName(skullName[whichSkull], PU_CACHE));
 #endif
 }
 

--- a/FASTDOOM/m_misc.c
+++ b/FASTDOOM/m_misc.c
@@ -315,7 +315,7 @@ default_t defaults[] =
         {"nomelt", &noMelt, 0},
         {"invisibleRender", &invisibleRender, 0},
         {"visplaneRender", &visplaneRender, 0},
-        {"selectedCPU", &selectedCPU, 0},
+        {"selectedCPU", &selectedCPU, -1 /* Means automatically detect */},
         {"vsync", &waitVsync, 0},
 
         {"autorun", &autorun, 0},

--- a/FASTDOOM/makefile
+++ b/FASTDOOM/makefile
@@ -24,16 +24,18 @@
 # --------------------------------------------------------------------------
 
 # Build options for 486DX/SX
-#CCOPTS = $(EXTERNOPT) -omaxtnrih -ol+ -oe=32 -zp4 -4r -ei -j -zq -zc
+#CCOPTS = $(EXTERNOPT) -omaxtnrih -ol+ -oe=32 -zp4 -4r -ei -j -zq -zc $(WCCOPTS)
 
 # Build options for 386DX/SX
-CCOPTS = $(EXTERNOPT) -omaxtnrih -ol+ -oe=32 -zp4 -3r -ei -j -zq -zc
+CCOPTS = $(EXTERNOPT) -omaxtnrih -ol+ -oe=32 -zp4 -3r -ei -j -zq -zc $(WCCOPTS)
 
 # Build options for Pentium
-#CCOPTS = $(EXTERNOPT) -omaxtnrih -ol+ -oe=32 -zp4 -5r -ei -j -zq -zc
+#CCOPTS = $(EXTERNOPT) -omaxtnrih -ol+ -oe=32 -zp4 -5r -ei -j -zq -zc $(WCCOPTS)
 
 # Build options for profiling (Pentium required)
-#CCOPTS = $(EXTERNOPT) -omaxtnrih -ol+ -oe=32 -zp4 -5r -ei -j -zq -zc -et
+#CCOPTS = $(EXTERNOPT) -omaxtnrih -ol+ -oe=32 -zp4 -5r -ei -j -zq -zc -et $(WCCOPTS)
+
+NASMOPTS = $(EXTERNOPT) $(NASMOPT)
 
 GLOBOBJS = &
  i_cgaafh.obj &
@@ -193,7 +195,7 @@ fdoom.exe : $(GLOBOBJS)
  wcc386 $(CCOPTS) -fo=$[*.obj $[*.c
 
 .asm.obj :
- nasm $(EXTERNOPT) -Oxv -f obj -o $[*.obj $[*.asm
+ nasm $(NASMOPTS) -Oxv -f obj -o $[*.obj $[*.asm
 
 !ifndef __LINUX__
 DELCMD = del
@@ -212,4 +214,4 @@ clean : .SYMBOLIC
  $(DELCMD) *.ERR
  $(DELCMD) *.OBJ
  $(DELCMD) *.SYM
- 
+

--- a/FASTDOOM/r_defs.h
+++ b/FASTDOOM/r_defs.h
@@ -37,6 +37,17 @@
 
 #define MAXDRAWSEGS 256
 
+
+// For low res modes, use bytes to save space, otherwise use shorts for
+// coordinates and offsets.
+#ifdef HI_RES
+typedef unsigned short pixelcoord_t;
+#define PIXELCOORD_MAX 0xFFFF
+#else
+typedef byte pixelcoord_t;
+#define PIXELCOORD_MAX 0xFF
+#endif
+
 //
 // INTERNAL MAP TYPES
 //  used by play and refresh
@@ -107,7 +118,7 @@ typedef struct
     // thinker_t for reversable actions
     void *specialdata;
 
-    short linecount;
+    pixelcoord_t linecount;
     struct line_s **lines; // [linecount] size
 
 } sector_t;
@@ -421,11 +432,11 @@ typedef struct
     byte pad1;
     // Here lies the rub for all
     //  dynamic resize/change of resolution.
-    byte top[SCREENWIDTH];
+    pixelcoord_t top[SCREENWIDTH];
     byte pad2;
     byte pad3;
     // See above.
-    byte bottom[SCREENWIDTH];
+    pixelcoord_t bottom[SCREENWIDTH];
     byte pad4;
 
 } visplane_t;

--- a/FASTDOOM/r_draw.c
+++ b/FASTDOOM/r_draw.c
@@ -26,6 +26,7 @@
 #include "z_zone.h"
 #include "w_wad.h"
 #include "r_data.h"
+#include "i_debug.h"
 
 #include "r_local.h"
 

--- a/FASTDOOM/r_draw.c
+++ b/FASTDOOM/r_draw.c
@@ -42,9 +42,6 @@
 #include "i_text.h"
 #endif
 
-// status bar height at bottom of screen
-#define SBARHEIGHT 32
-
 //
 // All drawing to the view buffer is accomplished in this file.
 // The other refresh files only know about ccordinates,
@@ -231,7 +228,7 @@ void R_DrawSkyFlatVBE2(void)
     if (count < 0)
         return;
 
-    dest = destview + Mul320(dc_yl) + dc_x;
+    dest = destview + MulScreenWidth(dc_yl) + dc_x;
 
     do
     {
@@ -245,7 +242,7 @@ void R_DrawSkyFlatLowVBE2(void)
     int count;
     unsigned short *dest;
 
-    dest = (unsigned short *)((byte *)destview + Mul320(dc_yl) + (dc_x << 1));
+    dest = (unsigned short *)((byte *)destview + MulScreenWidth(dc_yl) + (dc_x << 1));
     count = dc_yh - dc_yl;
 
     while (count >= 3)
@@ -271,7 +268,7 @@ void R_DrawSkyFlatPotatoVBE2(void)
     int count;
     unsigned int *dest;
 
-    dest = (unsigned int *)((byte *)destview + Mul320(dc_yl) + (dc_x << 2));
+    dest = (unsigned int *)((byte *)destview + MulScreenWidth(dc_yl) + (dc_x << 2));
     count = dc_yh - dc_yl;
 
     while (count >= 3)
@@ -305,7 +302,7 @@ void R_DrawFuzzColumnFlatSaturnVBE2(void)
 
     initialdrawpos = (dc_yl + dc_x) & 1;
 
-    dest = destview + Mul320(dc_yl) + dc_x;
+    dest = destview + MulScreenWidth(dc_yl) + dc_x;
 
     if (initialdrawpos)
     {
@@ -346,7 +343,7 @@ void R_DrawFuzzColumnSaturnVBE2(void)
 
     initialdrawpos = (dc_yl + dc_x) & 1;
 
-    dest = destview + Mul320(dc_yl) + dc_x;
+    dest = destview + MulScreenWidth(dc_yl) + dc_x;
 
     fracstep = dc_iscale;
     frac = dc_texturemid + (dc_yl - centery) * fracstep;
@@ -392,7 +389,7 @@ void R_DrawFuzzColumnTransVBE2(void)
     if (count <= 0)
         return;
 
-    dest = destview + Mul320(dc_yl) + dc_x;
+    dest = destview + MulScreenWidth(dc_yl) + dc_x;
 
     fracstep = dc_iscale;
     frac = dc_texturemid + (dc_yl - centery) * fracstep;
@@ -418,7 +415,7 @@ void R_DrawFuzzColumnFlatSaturnLowVBE2(void)
 
     initialdrawpos = (dc_yl + dc_x) & 1;
 
-    dest = destview + Mul320(dc_yl) + (dc_x << 1);
+    dest = destview + MulScreenWidth(dc_yl) + (dc_x << 1);
 
     if (initialdrawpos)
     {
@@ -459,7 +456,7 @@ void R_DrawFuzzColumnSaturnLowVBE2(void)
 
     initialdrawpos = (dc_yl + dc_x) & 1;
 
-    dest = destview + Mul320(dc_yl) + (dc_x << 1);
+    dest = destview + MulScreenWidth(dc_yl) + (dc_x << 1);
 
     fracstep = dc_iscale;
     frac = dc_texturemid + (dc_yl - centery) * fracstep;
@@ -514,7 +511,7 @@ void R_DrawFuzzColumnTransLowVBE2(void)
     if (count <= 0)
         return;
 
-    dest = destview + Mul320(dc_yl) + (dc_x << 1);
+    dest = destview + MulScreenWidth(dc_yl) + (dc_x << 1);
 
     fracstep = dc_iscale;
     frac = dc_texturemid + (dc_yl - centery) * fracstep;
@@ -544,7 +541,7 @@ void R_DrawFuzzColumnFlatSaturnPotatoVBE2(void)
 
     initialdrawpos = (dc_yl + dc_x) & 1;
 
-    dest = destview + Mul320(dc_yl) + (dc_x << 2);
+    dest = destview + MulScreenWidth(dc_yl) + (dc_x << 2);
 
     if (initialdrawpos)
     {
@@ -585,7 +582,7 @@ void R_DrawFuzzColumnSaturnPotatoVBE2(void)
 
     initialdrawpos = (dc_yl + dc_x) & 1;
 
-    dest = destview + Mul320(dc_yl) + (dc_x << 2);
+    dest = destview + MulScreenWidth(dc_yl) + (dc_x << 2);
 
     fracstep = dc_iscale;
     frac = dc_texturemid + (dc_yl - centery) * fracstep;
@@ -646,7 +643,7 @@ void R_DrawFuzzColumnTransPotatoVBE2(void)
     if (count <= 0)
         return;
 
-    dest = destview + Mul320(dc_yl) + (dc_x << 2);
+    dest = destview + MulScreenWidth(dc_yl) + (dc_x << 2);
 
     fracstep = dc_iscale;
     frac = dc_texturemid + (dc_yl - centery) * fracstep;
@@ -672,7 +669,7 @@ void R_DrawSpanFlatVBE2(void)
 
     lighttable_t color = ds_colormap[ds_source[FLATPIXELCOLOR]];
 
-    dest = destview + Mul320(ds_y) + ds_x1;
+    dest = destview + MulScreenWidth(ds_y) + ds_x1;
 
     countp = ds_x2 - ds_x1 + 1;
 
@@ -699,7 +696,7 @@ void R_DrawSpanFlatLowVBE2(void)
     unsigned short color = ds_colormap[ds_source[FLATPIXELCOLOR]];
     color |= color << 8;
 
-    dest = destview + Mul320(ds_y) + (ds_x1 << 1);
+    dest = destview + MulScreenWidth(ds_y) + (ds_x1 << 1);
 
     countp = ds_x2 - ds_x1 + 1;
 
@@ -727,7 +724,7 @@ void R_DrawSpanFlatPotatoVBE2(void)
     color |= color << 8;
     color |= color << 16;
 
-    dest = destview + Mul320(ds_y) + (ds_x1 << 2);
+    dest = destview + MulScreenWidth(ds_y) + (ds_x1 << 2);
 
     countp = ds_x2 - ds_x1 + 1;
 
@@ -2935,7 +2932,7 @@ void R_InitBuffer(int width, int height)
     viewwindowx = (SCREENWIDTH - width) >> 1;
 
 #if defined(MODE_13H) || defined(MODE_VBE2)
-    startscreen = Mul320(viewwindowy) + viewwindowx;
+    startscreen = MulScreenWidth(viewwindowy) + viewwindowx;
 #endif
 #endif
 
@@ -2953,7 +2950,7 @@ void R_InitBuffer(int width, int height)
 
 #if defined(MODE_13H) || defined(MODE_VBE2)
         startscreen = viewwindowx;
-        endscreen = Mul320(viewheight);
+        endscreen = MulScreenWidth(viewheight);
 #endif
     }
     else
@@ -2961,15 +2958,15 @@ void R_InitBuffer(int width, int height)
         viewwindowy = (SCREENHEIGHT - SBARHEIGHT - height) >> 1;
 
 #if defined(MODE_13H) || defined(MODE_VBE2)
-        startscreen = Mul320(viewwindowy) + viewwindowx;
-        endscreen = Mul320(viewwindowy + viewheight);
+        startscreen = MulScreenWidth(viewwindowy) + viewwindowx;
+        endscreen = MulScreenWidth(viewwindowy + viewheight);
 #endif
     }
 #endif
 
 #if defined(USE_BACKBUFFER)
     for (i = 0; i < height; i++)
-        ylookup[i] = backbuffer + Mul320(i + viewwindowy);
+        ylookup[i] = backbuffer + MulScreenWidth(i + viewwindowy);
 #endif
 #if defined(MODE_Y)
     for (i = 0; i < height; i++)
@@ -3003,7 +3000,7 @@ void R_FillBackScreen(void)
     char *name;
 
 #if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-    if (scaledviewwidth == 320)
+    if (scaledviewwidth == SCREENWIDTH)
         return;
 #endif
 
@@ -3035,11 +3032,13 @@ void R_FillBackScreen(void)
 #if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
     screen1 = (byte *)Z_MallocUnowned(SCREENWIDTH * SCREENHEIGHT, PU_STATIC);
     dest = screen1;
+#define TARGET_SURFACE screen1
 #endif
 #if defined(USE_BACKBUFFER)
     dest = background_buffer;
+#define TARGET_SURFACE background_buffer
 #endif
-
+    // Deal with screen width not being a multiple of 64
     for (y = 0; y < SCREENHEIGHT - SBARHEIGHT; y++)
     {
         for (x = 0; x < SCREENWIDTH / 64; x++)
@@ -3047,70 +3046,46 @@ void R_FillBackScreen(void)
             CopyDWords(src + ((y & 63) << 6), dest, 16);
             dest += 64;
         }
+        // Correct for underdraw
+        CopyDWords(src + ((y & 63) << 6), dest, (SCREENWIDTH % 64) / 4);
+        dest += (SCREENWIDTH % 64);
+
     }
+    // Draw beveled edge.
+    //I_Printf("Drawing bev404eled edge: %d %d %d %d\n", viewwindowx, viewwindowy, scaledviewwidth, viewheight);
 
     patch = W_CacheLumpName("BRDR_T", PU_CACHE);
 
     for (x = 0; x < scaledviewwidth; x += 8)
     {
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-        V_DrawPatch(viewwindowx + x, viewwindowy - 8, screen1, patch);
-#endif
-#if defined(USE_BACKBUFFER)
-        V_DrawPatch(viewwindowx + x, viewwindowy - 8, background_buffer, patch);
-#endif
+        V_DrawPatchNativeRes(viewwindowx + x, viewwindowy - 8, TARGET_SURFACE, patch);
     }
 
     patch = W_CacheLumpName("BRDR_B", PU_CACHE);
 
     for (x = 0; x < scaledviewwidth; x += 8)
     {
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-        V_DrawPatch(viewwindowx + x, viewwindowy + viewheight, screen1, patch);
-#endif
-#if defined(USE_BACKBUFFER)
-        V_DrawPatch(viewwindowx + x, viewwindowy + viewheight, background_buffer, patch);
-#endif
+        V_DrawPatchNativeRes(viewwindowx + x, viewwindowy + viewheight, TARGET_SURFACE, patch);
     }
     patch = W_CacheLumpName("BRDR_L", PU_CACHE);
 
     for (y = 0; y < viewheight; y += 8)
     {
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-        V_DrawPatch(viewwindowx - 8, viewwindowy + y, screen1, patch);
-#endif
-#if defined(USE_BACKBUFFER)
-        V_DrawPatch(viewwindowx - 8, viewwindowy + y, background_buffer, patch);
-#endif
+        V_DrawPatchNativeRes(viewwindowx - 8, viewwindowy + y, TARGET_SURFACE, patch);
     }
     patch = W_CacheLumpName("BRDR_R", PU_CACHE);
 
     for (y = 0; y < viewheight; y += 8)
     {
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-        V_DrawPatch(viewwindowx + scaledviewwidth, viewwindowy + y, screen1, patch);
-#endif
-#if defined(USE_BACKBUFFER)
-        V_DrawPatch(viewwindowx + scaledviewwidth, viewwindowy + y, background_buffer, patch);
-#endif
+        V_DrawPatchNativeRes(viewwindowx + scaledviewwidth, viewwindowy + y, TARGET_SURFACE, patch);
     }
 
-    // Draw beveled edge.
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-    V_DrawPatch(viewwindowx - 8, viewwindowy - 8, screen1, W_CacheLumpName("BRDR_TL", PU_CACHE));
-    V_DrawPatch(viewwindowx + scaledviewwidth, viewwindowy - 8, screen1, W_CacheLumpName("BRDR_TR", PU_CACHE));
-    V_DrawPatch(viewwindowx - 8, viewwindowy + viewheight, screen1, W_CacheLumpName("BRDR_BL", PU_CACHE));
-    V_DrawPatch(viewwindowx + scaledviewwidth, viewwindowy + viewheight, screen1, W_CacheLumpName("BRDR_BR", PU_CACHE));
-#endif
-#if defined(USE_BACKBUFFER)
-    V_DrawPatch(viewwindowx - 8, viewwindowy - 8, background_buffer, W_CacheLumpName("BRDR_TL", PU_CACHE));
-    V_DrawPatch(viewwindowx + scaledviewwidth, viewwindowy - 8, background_buffer, W_CacheLumpName("BRDR_TR", PU_CACHE));
-    V_DrawPatch(viewwindowx - 8, viewwindowy + viewheight, background_buffer, W_CacheLumpName("BRDR_BL", PU_CACHE));
-    V_DrawPatch(viewwindowx + scaledviewwidth, viewwindowy + viewheight, background_buffer, W_CacheLumpName("BRDR_BR", PU_CACHE));
-#endif
-
+    V_DrawPatchNativeRes(viewwindowx - 8, viewwindowy - 8, TARGET_SURFACE, W_CacheLumpName("BRDR_TL", PU_CACHE));
+    V_DrawPatchNativeRes(viewwindowx + scaledviewwidth, viewwindowy - 8, TARGET_SURFACE, W_CacheLumpName("BRDR_TR", PU_CACHE));
+    V_DrawPatchNativeRes(viewwindowx - 8, viewwindowy + viewheight, TARGET_SURFACE, W_CacheLumpName("BRDR_BL", PU_CACHE));
+    V_DrawPatchNativeRes(viewwindowx + scaledviewwidth, viewwindowy + viewheight, TARGET_SURFACE, W_CacheLumpName("BRDR_BR", PU_CACHE));
 #if defined(MODE_VBE2_DIRECT)
-    dest = pcscreen + 3 * 320 * 200;
+    dest = pcscreen + 3 * SCREENWIDTH * SCREENHEIGHT;
     CopyDWords(screen1, dest, (SCREENHEIGHT - SBARHEIGHT) * SCREENWIDTH / 4);
 #endif
 
@@ -3143,9 +3118,9 @@ void R_VideoErase(unsigned ofs, int count)
 {
     byte *dest;
     byte *source;
-
+    ASSERT((ofs + count) <= SCREENWIDTH * SCREENHEIGHT);
     dest = destscreen + ofs;
-    source = pcscreen + 320 * 200 * 3 + ofs; // Page 3
+    source = pcscreen + SCREENWIDTH * SCREENHEIGHT * 3 + ofs; // Page 3
 
     if (count & 1)
     {
@@ -3168,6 +3143,7 @@ void R_VideoErase(unsigned ofs, int count)
     byte *dest;
     byte *source;
     int countp;
+    ASSERT((ofs + count) <= SCREENWIDTH * SCREENHEIGHT);
 
     outp(SC_INDEX + 1, 15);
     outp(GC_INDEX, GC_MODE);
@@ -3184,11 +3160,13 @@ void R_VideoErase(unsigned ofs, int count)
 #if defined(USE_BACKBUFFER)
 void R_VideoErase(unsigned ofs, int count)
 {
+   // The erase function is called using
     // LFB copy.
     // This might not be a good idea if memcpy
     //  is not optiomal, e.g. byte by byte on
     //  a 32bit CPU, as GNU GCC/Linux libc did
     //  at one point.
+    ASSERT((ofs + count) <= SCREENWIDTH * SCREENHEIGHT);
 
     if (background_buffer)
     {
@@ -3203,7 +3181,7 @@ void R_VideoErase(unsigned ofs, int count)
         {
             CopyWords(background_buffer + ofs, backbuffer + ofs, count / 2);
         }
-        
+
     }
 }
 #endif
@@ -3228,14 +3206,14 @@ void R_DrawViewBorder(void)
     side = (SCREENWIDTH - scaledviewwidth) / 2;
 
     // copy top and one line of left side
-    R_VideoErase(0, Mul320(top) + side);
+    R_VideoErase(0, MulScreenWidth(top) + side);
 
     // copy one line of right side and bottom
-    ofs = Mul320(viewheight + top) - side;
-    R_VideoErase(ofs, Mul320(top) + side);
+    ofs = MulScreenWidth(viewheight + top) - side;
+    R_VideoErase(ofs, MulScreenWidth(top) + side);
 
     // copy sides using wraparound
-    ofs = Mul320(top) + SCREENWIDTH - side;
+    ofs = MulScreenWidth(top) + SCREENWIDTH - side;
     side <<= 1;
 
     for (i = 1; i < viewheight; i++)

--- a/FASTDOOM/r_main.c
+++ b/FASTDOOM/r_main.c
@@ -26,7 +26,7 @@
 #include "doomdef.h"
 #include "doomstat.h"
 #include "d_net.h"
-
+#include "i_debug.h"
 #include "m_misc.h"
 
 #include "r_local.h"
@@ -1633,6 +1633,17 @@ void R_ExecuteSetViewSize(void)
             scalelight[i][j] = colormaps + level * 256;
         }
     }
+    // I put this here so I could see which functions were having rendering
+    // problems. Leaving it here for demonstration purposes.
+#if (DEBUG_ENABLED==1)
+    I_Printf("R_InitData: %s", "test");
+    I_Printf("Render Functions:\n");
+    I_Printf("\tcolfunc: %s\n", I_LookupSymbolName(colfunc));
+    I_Printf("\tbasecolfunc: %s\n", I_LookupSymbolName(basecolfunc));
+    I_Printf("\tfuzzcolfunc: %s\n", I_LookupSymbolName(fuzzcolfunc));
+    I_Printf("\tspanfunc: %s\n", I_LookupSymbolName(spanfunc));
+    I_Printf("\tskyfunc: %s\n", I_LookupSymbolName(skyfunc));
+#endif
 }
 
 //

--- a/FASTDOOM/r_main.c
+++ b/FASTDOOM/r_main.c
@@ -848,6 +848,24 @@ void R_ExecuteSetViewSize(void)
 
     setsizeneeded = 0;
 
+    // TODO Add more granular detection
+    if (selectedCPU == AUTO_CPU) {
+      switch(I_GetCPUModel()) {
+        case 386:
+          selectedCPU = INTEL_386SX;
+          break;
+        case 486:
+          selectedCPU = INTEL_486;
+          break;
+        case 586:
+        case 686:
+          selectedCPU = INTEL_PENTIUM;
+          break;
+        default:
+          selectedCPU = INTEL_386SX;
+          break;
+      }
+    }
 #if !defined(MODE_T8050) && !defined(MODE_T8043) && !defined(MODE_T8025) && !defined(MODE_T4025) && !defined(MODE_T4050) && !defined(MODE_MDA)
     if (setblocks >= 11)
     {

--- a/FASTDOOM/r_main.c
+++ b/FASTDOOM/r_main.c
@@ -861,18 +861,25 @@ void R_ExecuteSetViewSize(void)
     }
     else
     {
-        scaledviewwidth = setblocks * 32;
-        viewheight = (setblocks * 168 / 10) & ~7;
+        // Since (SCREENWDITH / 10) may have a remainder, check 10 explcitly
+        if (setblocks == 10) {
+            scaledviewwidth = SCREENWIDTH;
+        } else {
+            scaledviewwidth = setblocks * (SCREENWIDTH / 10);
+            // Stay multiple of 4
+            scaledviewwidth &=~0x3;
+        }
+        viewheight = (setblocks * (SCREENHEIGHT - SBARHEIGHT) / 10) & ~7;
         viewheightminusone = viewheight - 1;
         viewheightshift = viewheight << FRACBITS;
         viewheightopt = (viewheight << FRACBITS) - viewheight;
         viewheight32 = viewheight << 16 | viewheight;
         automapheight = SCREENHEIGHT - 32;
     }
+#endif
 
 #if defined(MODE_13H) || defined(MODE_VBE2)
-    endscreen = Mul320(viewwindowy + viewheight);
-#endif
+    endscreen = MulScreenWidth(viewwindowy + viewheight);
 #endif
 
 #if defined(MODE_Y) || defined(USE_BACKBUFFER) || defined(MODE_VBE2_DIRECT)
@@ -1574,8 +1581,8 @@ void R_ExecuteSetViewSize(void)
 
     // psprite scales
 #if !defined(MODE_T8050) && !defined(MODE_T8043) && !defined(MODE_T8025) && !defined(MODE_T4025) && !defined(MODE_T4050) && !defined(MODE_MDA)
-    pspritescale = FRACUNIT * viewwidth / SCREENWIDTH;
-    pspriteiscale = FRACUNIT * SCREENWIDTH / viewwidth;
+    pspritescale = FRACUNIT * viewwidth / 320;
+    pspriteiscale = FRACUNIT * 320 / viewwidth;
     pspriteiscaleneg = -pspriteiscale;
 #endif
 
@@ -1617,13 +1624,13 @@ void R_ExecuteSetViewSize(void)
         for (j = 0; j < MAXLIGHTSCALE; j++)
         {
 #if defined(MODE_T4050)
-            level = startmap - Mul320(j) / (viewwidth << 1) / DISTMAP;
+            level = startmap - MulScreenWidth(j) / (viewwidth << 1) / DISTMAP;
 #endif
 #if defined(MODE_Y) || defined(USE_BACKBUFFER) || defined(MODE_VBE2_DIRECT)
-            level = startmap - Mul320(j) / (viewwidth << detailshift) / DISTMAP;
+            level = startmap - MulScreenWidth(j) / (viewwidth << detailshift) / DISTMAP;
 #endif
 #if defined(MODE_T8025) || defined(MODE_T8050) || defined(MODE_T8043) || defined(MODE_T4025) || defined(MODE_MDA)
-            level = startmap - Mul320(j) / (viewwidth) / DISTMAP;
+            level = startmap - MulScreenWidth(j) / (viewwidth) / DISTMAP;
 #endif
             if (level < 0)
                 level = 0;
@@ -1748,11 +1755,11 @@ void R_SetupFrame(void)
     validcount++;
 
 #if defined(MODE_VBE2_DIRECT)
-    destview = destscreen + Mul320(viewwindowy) + viewwindowx;
+    destview = destscreen + MulScreenWidth(viewwindowy) + viewwindowx;
 #endif
 
 #if defined(MODE_Y)
-    destview = destscreen + Mul80(viewwindowy) + (viewwindowx >> 2);
+    destview = destscreen + MulScreenWidthQuarter(viewwindowy) + (viewwindowx >> 2);
 #endif
 }
 

--- a/FASTDOOM/r_plane.c
+++ b/FASTDOOM/r_plane.c
@@ -23,6 +23,7 @@
 #include "options.h"
 #include "i_system.h"
 #include "i_ibm.h"
+#include "i_debug.h"
 #include "z_zone.h"
 #include "w_wad.h"
 
@@ -36,6 +37,7 @@
 #include "std_func.h"
 
 #include <conio.h>
+#include "i_debug.h"
 
 #include "sizeopt.h"
 

--- a/FASTDOOM/r_plane.c
+++ b/FASTDOOM/r_plane.c
@@ -109,15 +109,15 @@ void R_MapPlane(int y, int x1)
     fixed_t distance;
     fixed_t length;
     unsigned index;
-
+    if (y == PIXELCOORD_MAX)
+        return;
 #if defined(MODE_CGA16) || defined(MODE_CGA512) || defined(MODE_CGA_AFH)
     if (y & 1)
         return;
 #endif
-
+    BOUNDS_CHECK(x1, y);
     ds_x1 = x1;
     ds_y = y;
-
     if (visplaneRender == VISPLANES_FLAT)
     {
         if (planeheight != cachedheight[y])
@@ -292,7 +292,7 @@ visplane_t *R_CheckPlane(visplane_t *pl, int start, int stop)
         intrh = stop;
     }
 
-    for (x = intrl; x <= intrh && pl->top[x] == 0xff; x++) // dropoff overflow
+    for (x = intrl; x <= intrh && pl->top[x] == PIXELCOORD_MAX; x++) // dropoff overflow
         ;
 
     if (x > intrh)
@@ -328,7 +328,7 @@ void R_DrawPlanes(void)
 {
     visplane_t *pl;
     int light;
-    int x;
+    int x, i;
     int stop;
     int angle;
 
@@ -337,8 +337,7 @@ void R_DrawPlanes(void)
     int tex;
     int col;
 
-    byte t1, b1, t2, b2;
-
+    pixelcoord_t t1, b1, t2, b2;
     for (pl = visplanes; pl < lastvisplane; pl++)
     {
         if (!pl->modified || pl->minx > pl->maxx)
@@ -364,8 +363,8 @@ void R_DrawPlanes(void)
         else
             planezlight = zlight[light];
 
-        pl->top[pl->maxx + 1] = 0xff;
-        pl->top[pl->minx - 1] = 0xff;
+        pl->top[pl->maxx + 1] = PIXELCOORD_MAX;
+        pl->top[pl->minx - 1] = PIXELCOORD_MAX;
 
         stop = pl->maxx + 1;
 
@@ -447,7 +446,7 @@ void R_DrawPlanesFlatter(void)
 
             count = pl->bottom[x] - pl->top[x];
 
-            dest = destview + Mul80(pl->top[x]) + (x >> 2);
+            dest = destview + MulScreenWidthQuarter(pl->top[x]) + (x >> 2);
 
             while (count >= 3)
             {
@@ -487,7 +486,7 @@ void R_DrawPlanesFlatter(void)
 
             count = pl->bottom[x] - pl->top[x];
 
-            dest = destview + Mul80(pl->top[x]) + (x >> 2);
+            dest = destview + MulScreenWidthQuarter(pl->top[x]) + (x >> 2);
 
             while (count >= 3)
             {
@@ -527,7 +526,7 @@ void R_DrawPlanesFlatter(void)
 
             count = pl->bottom[x] - pl->top[x];
 
-            dest = destview + Mul80(pl->top[x]) + (x >> 2);
+            dest = destview + MulScreenWidthQuarter(pl->top[x]) + (x >> 2);
 
             while (count >= 3)
             {
@@ -567,7 +566,7 @@ void R_DrawPlanesFlatter(void)
 
             count = pl->bottom[x] - pl->top[x];
 
-            dest = destview + Mul80(pl->top[x]) + (x >> 2);
+            dest = destview + MulScreenWidthQuarter(pl->top[x]) + (x >> 2);
 
             while (count >= 3)
             {
@@ -631,7 +630,7 @@ void R_DrawPlanesFlatterLow(void)
 
             count = pl->bottom[x] - pl->top[x];
 
-            dest = destview + Mul80(pl->top[x]) + (x >> 1);
+            dest = destview + MulScreenWidthQuarter(pl->top[x]) + (x >> 1);
 
             while (count >= 3)
             {
@@ -671,7 +670,7 @@ void R_DrawPlanesFlatterLow(void)
 
             count = pl->bottom[x] - pl->top[x];
 
-            dest = destview + Mul80(pl->top[x]) + (x >> 1);
+            dest = destview + MulScreenWidthQuarter(pl->top[x]) + (x >> 1);
 
             while (count >= 3)
             {
@@ -729,7 +728,7 @@ void R_DrawPlanesFlatterPotato(void)
 
             count = pl->bottom[x] - pl->top[x];
 
-            dest = destview + Mul80(pl->top[x]) + x;
+            dest = destview + MulScreenWidthQuarter(pl->top[x]) + x;
 
             while (count >= 3)
             {
@@ -1301,7 +1300,7 @@ void R_DrawPlanesFlatterVBE2(void)
                 continue;
 
             count = pl->bottom[x] - pl->top[x];
-            dest = destview + Mul320(pl->top[x]) + x;
+            dest = destview + MulScreenWidth(pl->top[x]) + x;
 
             do
             {
@@ -1346,7 +1345,7 @@ void R_DrawPlanesFlatterLowVBE2(void)
                 continue;
 
             count = pl->bottom[x] - pl->top[x];
-            dest = (unsigned short *)((byte *)(destview + Mul320(pl->top[x]) + (x << 1)));
+            dest = (unsigned short *)((byte *)(destview + MulScreenWidth(pl->top[x]) + (x << 1)));
 
             do
             {
@@ -1392,7 +1391,7 @@ void R_DrawPlanesFlatterPotatoVBE2(void)
                 continue;
 
             count = pl->bottom[x] - pl->top[x];
-            dest = (unsigned int *)((byte *)(destview + Mul320(pl->top[x]) + (x << 2)));
+            dest = (unsigned int *)((byte *)(destview + MulScreenWidth(pl->top[x]) + (x << 2)));
 
             do
             {
@@ -1407,6 +1406,15 @@ void R_DrawPlanesFlatterPotatoVBE2(void)
 
 #endif
 
+#if defined(ASPECTRATIO16x10)
+#define SKY_SCALE 100
+#elif defined(ASPECTRATIO4x3)
+#define SKY_SCALE 80
+#elif defined(ASPECTRATIO5x4)
+#define SKY_SCALE 75
+#endif
+
+
 void R_DrawSky(visplane_t *pl)
 {
     int angle;
@@ -1420,7 +1428,7 @@ void R_DrawSky(visplane_t *pl)
 
     if (!flatSky)
     {
-        dc_iscale = pspriteiscaleshifted;
+        dc_iscale = (pspriteiscaleshifted * SKY_SCALE) / 100;
 
         dc_colormap = fixedcolormap ? fixedcolormap : colormaps;
         dc_texturemid = 100 * FRACUNIT;

--- a/FASTDOOM/r_things.c
+++ b/FASTDOOM/r_things.c
@@ -40,7 +40,16 @@
 #define SC_INDEX 0x3C4
 
 #define MINZ (FRACUNIT * 4)
+// If we are 4x5 aspect ratio
+#if defined(ASPECTRATIO4x3)
+#define BASEYCENTER 80
+#elif defined(ASPECTRATIO16x10)
 #define BASEYCENTER 100
+#elif defined(ASPECTRATIO5x4)
+#define BASEYCENTER 70
+#else
+#error "Unknown aspect ratio"
+#endif
 
 #define INITIAL_SPRITES 128
 
@@ -333,7 +342,7 @@ void R_DrawVisSprite(vissprite_t *vis)
 
             dc_source = (byte *)column + 3;
             dc_texturemid = basetexturemid - (column->topdelta << FRACBITS);
-
+            BOUNDS_CHECK(yh, yl);
             dc_yh = yh;
             dc_yl = yl;
 

--- a/FASTDOOM/r_things.c
+++ b/FASTDOOM/r_things.c
@@ -23,6 +23,7 @@
 #include "doomstat.h"
 
 #include "i_system.h"
+#include "i_debug.h"
 #include "z_zone.h"
 #include "w_wad.h"
 

--- a/FASTDOOM/st_lib.c
+++ b/FASTDOOM/st_lib.c
@@ -123,12 +123,7 @@ void STlib_drawNum(st_number_t *n, byte refresh)
     // in the special case of 0, you draw 0
     if (!num)
     {
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-        V_DrawPatchScreen0(x - w, n->y, n->p[0]);
-#endif
-#if defined(USE_BACKBUFFER)
-        V_DrawPatchDirect(x - w, n->y, n->p[0]);
-#endif
+        V_DrawPatchMode(x - w, n->y, n->p[0]);
         return;
     }
 
@@ -139,12 +134,7 @@ void STlib_drawNum(st_number_t *n, byte refresh)
 
         num = Div10(num);
         x -= w;
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-        V_DrawPatchScreen0(x, n->y, n->p[original - Mul10(num)]);
-#endif
-#if defined(USE_BACKBUFFER)
-        V_DrawPatchDirect(x, n->y, n->p[original - Mul10(num)]);
-#endif
+        V_DrawPatchMode(x, n->y, n->p[original - Mul10(num)]);
     } while (num);
 }
 
@@ -220,12 +210,7 @@ void STlib_updatePercent(st_percent_t *per, int refresh)
 {
     if (refresh && *per->n.on)
     {
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-        V_DrawPatchScreen0(per->n.x, per->n.y, per->p);
-#endif
-#if defined(USE_BACKBUFFER)
-        V_DrawPatchDirect(per->n.x, per->n.y, per->p);
-#endif
+        V_DrawPatchMode(per->n.x, per->n.y, per->p);
     }
 
     STlib_updateNum(&per->n, refresh);
@@ -290,12 +275,7 @@ void STlib_updateMultIcon(st_multicon_t *mi, byte refresh)
             V_CopyRect(x, y - ST_Y, screen4, w, h, x, y, backbuffer);
 #endif
         }
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-        V_DrawPatchScreen0(mi->x, mi->y, mi->p[*mi->inum]);
-#endif
-#if defined(USE_BACKBUFFER)
-        V_DrawPatchDirect(mi->x, mi->y, mi->p[*mi->inum]);
-#endif
+        V_DrawPatchMode(mi->x, mi->y, mi->p[*mi->inum]);
         mi->oldinum = *mi->inum;
 
 #if defined(USE_BACKBUFFER)
@@ -322,12 +302,7 @@ void STlib_updateBinIcon(st_binicon_t *bi, byte refresh)
 {
     if (*bi->on && refresh)
     {
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-        V_DrawPatchScreen0(bi->x, bi->y, bi->p);
-#endif
-#if defined(USE_BACKBUFFER)
-        V_DrawPatchDirect(bi->x, bi->y, bi->p);
-#endif
+        V_DrawPatchMode(bi->x, bi->y, bi->p);
 
 #if defined(USE_BACKBUFFER)
         updatestate |= I_STATBAR;

--- a/FASTDOOM/st_stuff.c
+++ b/FASTDOOM/st_stuff.c
@@ -108,8 +108,8 @@
 #define ST_GODFACE (ST_NUMPAINFACES * ST_FACESTRIDE)
 #define ST_DEADFACE (ST_GODFACE + 1)
 
-#define ST_FACESX 143
-#define ST_FACESY 168
+#define ST_FACESX CENTERING_OFFSET_X + 143
+#define ST_FACESY SCALED_SCREENHEIGHT-32
 
 #define ST_EVILGRINCOUNT (2 * TICRATE)
 #define ST_STRAIGHTFACECOUNT (TICRATE / 2)
@@ -129,111 +129,114 @@
 
 // AMMO number pos.
 #define ST_AMMOWIDTH 3
-#define ST_AMMOX 44
-#define ST_AMMOY 171
+#define ST_AMMOX CENTERING_OFFSET_X + 44
+#define ST_AMMOY SCALED_SCREENHEIGHT-29
 
 // HEALTH number pos.
 #define ST_HEALTHWIDTH 3
-#define ST_HEALTHX 90
-#define ST_HEALTHY 171
+#define ST_HEALTHX CENTERING_OFFSET_X + 90
+#define ST_HEALTHY SCALED_SCREENHEIGHT-29
 
-// Weapon pos.
-#define ST_ARMSX 111
-#define ST_ARMSY 172
-#define ST_ARMSBGX 104
-#define ST_ARMSBGY 168
+
+#define ST_ARMSX CENTERING_OFFSET_X + 111
+#define ST_ARMSY SCALED_SCREENHEIGHT-28
+#define ST_ARMSBGX CENTERING_OFFSET_X + 104
+#define ST_ARMSBGY SCALED_SCREENHEIGHT-32
 #define ST_ARMSXSPACE 12
 #define ST_ARMSYSPACE 10
 
 // ARMOR number pos.
 #define ST_ARMORWIDTH 3
-#define ST_ARMORX 221
-#define ST_ARMORY 171
+#define ST_ARMORX CENTERING_OFFSET_X + 221
+#define ST_ARMORY SCALED_SCREENHEIGHT-29
 
 // Key icon positions.
-#define ST_KEY0WIDTH 8
-#define ST_KEY0HEIGHT 5
-#define ST_KEY0X 239
-#define ST_KEY0Y 171
+#define ST_KEY0WIDTH (8)
+#define ST_KEY0HEIGHT (5)
+#define ST_KEY0X CENTERING_OFFSET_X + 239
+#define ST_KEY0Y SCALED_SCREENHEIGHT-29
 #define ST_KEY1WIDTH ST_KEY0WIDTH
-#define ST_KEY1X 239
-#define ST_KEY1Y 181
+#define ST_KEY1X CENTERING_OFFSET_X + 239
+#define ST_KEY1Y SCALED_SCREENHEIGHT-19
 #define ST_KEY2WIDTH ST_KEY0WIDTH
-#define ST_KEY2X 239
-#define ST_KEY2Y 191
+#define ST_KEY2X CENTERING_OFFSET_X + 239
+#define ST_KEY2Y SCALED_SCREENHEIGHT-9
 
 // Ammunition counter.
-#define ST_AMMO0WIDTH 3
-#define ST_AMMO0HEIGHT 6
-#define ST_AMMO0X 288
-#define ST_AMMO0Y 173
+#define ST_AMMO0WIDTH (3)
+#define ST_AMMO0HEIGHT (6)
+#define ST_AMMO0X CENTERING_OFFSET_X + 288
+#define ST_AMMO0Y SCALED_SCREENHEIGHT-28
 #define ST_AMMO1WIDTH ST_AMMO0WIDTH
-#define ST_AMMO1X 288
-#define ST_AMMO1Y 179
+#define ST_AMMO1X CENTERING_OFFSET_X + 288
+#define ST_AMMO1Y SCALED_SCREENHEIGHT-21
 #define ST_AMMO2WIDTH ST_AMMO0WIDTH
-#define ST_AMMO2X 288
-#define ST_AMMO2Y 191
+#define ST_AMMO2X CENTERING_OFFSET_X + 288
+#define ST_AMMO2Y SCALED_SCREENHEIGHT-9
 #define ST_AMMO3WIDTH ST_AMMO0WIDTH
-#define ST_AMMO3X 288
-#define ST_AMMO3Y 185
+#define ST_AMMO3X CENTERING_OFFSET_X + 288
+#define ST_AMMO3Y SCALED_SCREENHEIGHT-15
 
 // Indicate maximum ammunition.
 // Only needed because backpack exists.
-#define ST_MAXAMMO0WIDTH 3
-#define ST_MAXAMMO0HEIGHT 5
-#define ST_MAXAMMO0X 314
-#define ST_MAXAMMO0Y 173
-#define ST_MAXAMMO1WIDTH ST_MAXAMMO0WIDTH
-#define ST_MAXAMMO1X 314
-#define ST_MAXAMMO1Y 179
-#define ST_MAXAMMO2WIDTH ST_MAXAMMO0WIDTH
-#define ST_MAXAMMO2X 314
-#define ST_MAXAMMO2Y 191
-#define ST_MAXAMMO3WIDTH ST_MAXAMMO0WIDTH
-#define ST_MAXAMMO3X 314
-#define ST_MAXAMMO3Y 185
+#define ST_MAXAMMO0WIDTH (3)
+#define ST_MAXAMMO0HEIGHT (5)
+#define ST_MAXAMMO0X CENTERING_OFFSET_X + 314
+#define ST_MAXAMMO0Y SCALED_SCREENHEIGHT-27
 
+#define ST_MAXAMMO1WIDTH ST_MAXAMMO0WIDTH
+#define ST_MAXAMMO1X CENTERING_OFFSET_X + 314
+#define ST_MAXAMMO1Y SCALED_SCREENHEIGHT-21
+#define ST_MAXAMMO2WIDTH ST_MAXAMMO0WIDTH
+#define ST_MAXAMMO2X CENTERING_OFFSET_X + 314
+#define ST_MAXAMMO2Y SCALED_SCREENHEIGHT-9
+#define ST_MAXAMMO3WIDTH ST_MAXAMMO0WIDTH
+#define ST_MAXAMMO3X CENTERING_OFFSET_X + 314
+#define ST_MAXAMMO3Y SCALED_SCREENHEIGHT-15
+
+// Looks like these are no longer used
+/*
 // pistol
-#define ST_WEAPON0X 110
-#define ST_WEAPON0Y 172
+#define ST_WEAPON0X CENTERING_OFFSET_X + 110
+#define ST_WEAPON0Y (SCREENWIDTH + 12 * SCREENMUL)
 
 // shotgun
-#define ST_WEAPON1X 122
+#define ST_WEAPON1X CENTERING_OFFSET_X + 122
 #define ST_WEAPON1Y 172
 
 // chain gun
-#define ST_WEAPON2X 134
+#define ST_WEAPON2X CENTERING_OFFSET_X + 134
 #define ST_WEAPON2Y 172
 
 // missile launcher
-#define ST_WEAPON3X 110
+#define ST_WEAPON3X CENTERING_OFFSET_X + 110
 #define ST_WEAPON3Y 181
 
 // plasma gun
-#define ST_WEAPON4X 122
+#define ST_WEAPON4X CENTERING_OFFSET_X + 122
 #define ST_WEAPON4Y 181
 
 // bfg
-#define ST_WEAPON5X 134
+#define ST_WEAPON5X CENTERING_OFFSET_X + 134
 #define ST_WEAPON5Y 181
 
 // WPNS title
-#define ST_WPNSX 109
+#define ST_WPNSX CENTERING_OFFSET_X + 109
 #define ST_WPNSY 191
 
 // DETH title
-#define ST_DETHX 109
+#define ST_DETHX CENTERING_OFFSET_X + 109
 #define ST_DETHY 191
 
 // Incoming messages window location
-#define ST_MSGTEXTX 0
+#define ST_MSGTEXTX CENTERING_OFFSET_X + 0
 #define ST_MSGTEXTY 0
 // Dimensions given in characters.
 #define ST_MSGWIDTH 52
 // Or shall I say, in lines?
 #define ST_MSGHEIGHT 1
 
-#define ST_OUTTEXTX 0
+#define ST_OUTTEXTX CENTERING_OFFSET_X + 0
 #define ST_OUTTEXTY 6
 
 // Width, in characters again.
@@ -243,6 +246,7 @@
 
 #define ST_MAPTITLEY 0
 #define ST_MAPHEIGHT 1
+*/
 
 // ST_Start() has just been called
 static byte st_firsttime;
@@ -381,15 +385,39 @@ void ST_Stop(void);
 #if defined(MODE_Y) || defined(USE_BACKBUFFER) || defined(MODE_VBE2_DIRECT)
 void ST_refreshBackground(void)
 {
-	if (st_statusbaron)
-	{
-		V_DrawPatch(ST_X, 0, screen4, sbar);
+ if (st_statusbaron)
+ {
+  if (CENTERING_OFFSET_X) {
+    // We need to draw the border texture around the space surrounding the
+    // status bar.
+    unsigned char* src;
+    byte* dest = screen4;
+    int y, x;
+    if (gamemode != commercial)
+      src = W_CacheLumpName("FLOOR7_2", PU_CACHE);
+    else
+      src = W_CacheLumpName("GRNROCK", PU_CACHE);
+    for (y = 0; y < SBARHEIGHT; y++) {
+      for (x = 0; x < SCREENWIDTH-63; x += 64) {
+        CopyDWords(src + (((y + (SCREENHEIGHT - SBARHEIGHT)) & 63) << 6), dest, 16);
+        dest += 64;
+      }
+      // Copy the remaining, assuming we can copy 4 bytes at a time.
+      ASSERT((SCREENWIDTH & 0x3) == 0);
+      CopyDWords(src + (((y + (SCREENHEIGHT - SBARHEIGHT)) & 63) << 6), dest, SCREENWIDTH % 64 / 4);
+      dest += SCREENWIDTH % 64;
+    }
+    // Copy the remaining part of the border texture
 
+  }
+   V_DrawPatch(CENTERING_OFFSET_X, 0, screen4, sbar);
+
+   // Copy the entire width of the status bar, which is SCALED_SCREENWIDTH
 #if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-		V_CopyRect(ST_X, 0, screen4, ST_WIDTH, ST_HEIGHT, ST_X, ST_Y, screen0);
+		V_CopyRect(0, 0, screen4, SCALED_SCREENWIDTH, ST_HEIGHT, 0, ST_Y, screen0);
 #endif
 #if defined(USE_BACKBUFFER)
-		V_CopyRect(ST_X, 0, screen4, ST_WIDTH, ST_HEIGHT, ST_X, ST_Y, backbuffer);
+		V_CopyRect(0, 0, screen4, SCALED_SCREENWIDTH, ST_HEIGHT, 0, ST_Y, backbuffer);
 #endif
 
 #if defined(USE_BACKBUFFER)
@@ -1471,8 +1499,8 @@ void ST_createWidgets_mini(void)
 {
 	// ready weapon ammo
 	STlib_initNum(&w_ready,
-				  270,
-				  170,
+				  SCALED_SCREENWIDTH - 50,
+				  SCALED_SCREENHEIGHT - 30,
 				  shortnum,
 				  &players.ammo[weaponinfo[players.readyweapon].ammo],
 				  &st_statusbaron);
@@ -1482,46 +1510,46 @@ void ST_createWidgets_mini(void)
 
 	// health percentage
 	STlib_initNum(&(w_health.n),
-				  270,
-				  180,
+				  SCALED_SCREENWIDTH - 50,
+				  SCALED_SCREENHEIGHT - 20,
 				  shortnum,
 				  &players.health,
 				  &st_statusbaron);
 
 	// faces
 	STlib_initMultIcon(&w_faces,
-					   285,
-					   165,
+					   SCALED_SCREENWIDTH - 35,
+					   SCALED_SCREENHEIGHT - 35,
 					   faces,
 					   &st_faceindex,
 					   &st_statusbaron);
 
 	// armor percentage - should be colored later
 	STlib_initNum(&(w_armor.n),
-				  270,
-				  190,
+				  SCALED_SCREENWIDTH - 50,
+				  SCALED_SCREENHEIGHT - 10,
 				  shortnum,
 				  &players.armorpoints,
 				  &st_statusbaron);
 
 	// keyboxes 0-2
 	STlib_initMultIcon(&w_keyboxes[0],
-					   275,
-					   169,
+					   SCALED_SCREENWIDTH - 45,
+					   SCALED_SCREENHEIGHT - 31,
 					   keys,
 					   &keyboxes[0],
 					   &st_statusbaron);
 
 	STlib_initMultIcon(&w_keyboxes[1],
-					   275,
-					   179,
+					   SCALED_SCREENWIDTH - 45,
+					   SCALED_SCREENHEIGHT - 21,
 					   keys,
 					   &keyboxes[1],
 					   &st_statusbaron);
 
 	STlib_initMultIcon(&w_keyboxes[2],
-					   275,
-					   189,
+					   SCALED_SCREENWIDTH - 45,
+					   SCALED_SCREENHEIGHT - 11,
 					   keys,
 					   &keyboxes[2],
 					   &st_statusbaron);

--- a/FASTDOOM/st_stuff.c
+++ b/FASTDOOM/st_stuff.c
@@ -57,6 +57,8 @@
 
 #include "m_menu.h"
 
+#include "i_debug.h"
+
 //
 // STATUS BAR DATA
 //

--- a/FASTDOOM/st_stuff.h
+++ b/FASTDOOM/st_stuff.h
@@ -25,10 +25,9 @@
 #include "d_event.h"
 
 // Size of statusbar.
-// Now sensitive for scaling.
-#define ST_HEIGHT 32 * SCREEN_MUL
-#define ST_WIDTH SCREENWIDTH
-#define ST_Y (SCREENHEIGHT - ST_HEIGHT)
+#define ST_HEIGHT 32
+#define ST_WIDTH 320
+#define ST_Y (SCALED_SCREENHEIGHT - ST_HEIGHT)
 #define ST_BACKGROUND_COLOR 108
 
 //

--- a/FASTDOOM/v_video.c
+++ b/FASTDOOM/v_video.c
@@ -40,7 +40,11 @@ byte screen0[SCREENWIDTH * SCREENHEIGHT];
 #endif
 
 #if defined(MODE_Y) || defined(USE_BACKBUFFER) || defined(MODE_VBE2_DIRECT)
-byte screen4[SCREENWIDTH * 32];
+byte screen4[SCREENWIDTH * SBARHEIGHT];
+#if PIXEL_SCALING!=1 && PIXEL_SCALING!=2
+#error "PIXEL_SCALING must be 1 or 2"
+#endif
+
 #endif
 
 #if defined(USE_BACKBUFFER)
@@ -77,6 +81,8 @@ int usegamma;
 #if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
 void V_MarkRect(int x, int y, int width, int height)
 {
+    BOUNDS_CHECK(x, y);
+    BOUNDS_CHECK(x + width - 1, y + height - 1);
     M_AddToBox(dirtybox, x, y);
     M_AddToBox(dirtybox, x + width - 1, y + height - 1);
 }
@@ -89,13 +95,27 @@ void V_CopyRect(int srcx, int srcy, byte *srcscrn, int width, int height, int de
 {
     byte *src;
     byte *dest;
+    // The buffers are pixel doubled in hi-res mode
+#if PIXEL_SCALING==2
+    srcx *= 2;
+    srcy *= 2;
+    destx *= 2;
+    desty *= 2;
+    width *= 2;
+    height *= 2;
+#endif
+    BOUNDS_CHECK(srcx, srcy);
+    BOUNDS_CHECK(srcx + width - 1, srcy + height - 1);
+    BOUNDS_CHECK(destx, desty);
+    BOUNDS_CHECK(destx + width - 1, desty + height - 1);
 
 #if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
     V_MarkRect(destx, desty, width, height);
 #endif
 
-    src = srcscrn + Mul320(srcy) + srcx;
-    dest = destscrn + Mul320(desty) + destx;
+    src = srcscrn + MulScreenWidth(srcy) + srcx;
+    dest = destscrn + MulScreenWidth(desty) + destx;
+
 
     if (width & 1)
     {
@@ -138,11 +158,116 @@ void V_DrawPatch(int x, int y, byte *scrn, patch_t *patch)
     byte *dest;
     byte *source;
     int w;
+    SCALED_BOUNDS_CHECK(x, y);
+    y -= patch->topoffset;
+    x -= patch->leftoffset;
+    SCALED_BOUNDS_CHECK(x, y);
 
+    desttop = scrn + MulScreenWidth(y * PIXEL_SCALING) + x * PIXEL_SCALING;
+
+    w = patch->width;
+    for (; col < w; x++, col++, desttop+=PIXEL_SCALING)
+    {
+        column = (column_t *)((byte *)patch + patch->columnofs[col]);
+
+        // step through the posts in a column
+        while (column->topdelta != 0xff)
+        {
+            register const byte *source = (byte *)column + 3;
+            register byte *dest = desttop + MulScreenWidth(column->topdelta * PIXEL_SCALING);
+            register int count = column->length;
+            register byte s0, s1;
+#if PIXEL_SCALING==1
+            if ((count -= 4) >= 0)
+                do
+                {
+                    s0 = source[0];
+                    s1 = source[1];
+                    dest[0] = s0;
+                    dest[1] = s1;
+                    dest[SCREENWIDTH] = s1;
+                    dest += SCREENWIDTH * 2;
+                    s0 = source[2];
+                    s1 = source[3];
+                    dest[0] = s0;
+                    dest[1] = s1;
+                    dest[SCREENWIDTH] = s1;
+                    dest += SCREENWIDTH * 2;
+                    source += 4;
+                } while ((count -= 4) >= 0);
+            if (count += 4)
+                do
+                {
+                    *dest = *source++;
+                    dest += SCREENWIDTH;
+                } while (--count);
+#elif PIXEL_SCALING==2
+              if ((count -= 4) >= 0)
+                  do {
+                      s0 = source[0];
+                      s1 = source[1];
+                      dest[0] = s0;
+                      dest[1] = s0;
+                      dest += SCREENWIDTH;
+                      dest[0] = s0;
+                      dest[1] = s0;
+                      dest += SCREENWIDTH;
+                      dest[0] = s1;
+                      dest[1] = s1;
+                      dest += SCREENWIDTH;
+                      dest[0] = s1;
+                      dest[1] = s1;
+                      dest += SCREENWIDTH;
+                      s0 = source[2];
+                      s1 = source[3];
+                      dest[0] = s0;
+                      dest[1] = s0;
+                      dest += SCREENWIDTH;
+                      dest[0] = s0;
+                      dest[1] = s0;
+                      dest += SCREENWIDTH;
+                      dest[0] = s1;
+                      dest[1] = s1;
+                      dest += SCREENWIDTH;
+                      dest[0] = s1;
+                      dest[1] = s1;
+                      dest += SCREENWIDTH;
+                      source += 4;
+                  } while ((count -= 4) >= 0);
+              if (count += 4)
+                  do
+                  {
+                      byte s0 = *source++;
+                      dest[0] = s0;
+                      dest[1] = s0;
+                      dest += SCREENWIDTH;
+                      dest[0] = s0;
+                      dest[1] = s0;
+                      dest += SCREENWIDTH;
+                  } while (--count);
+#endif
+            column = (column_t *)(source + 1);
+        }
+    }
+}
+#endif
+
+#if PIXEL_SCALING!=1
+void V_DrawPatchNativeRes(int x, int y, byte *scrn, patch_t *patch)
+{
+
+    int count;
+    int col = 0;
+    column_t *column;
+    byte *desttop;
+    byte *dest;
+    byte *source;
+    int w;
+    BOUNDS_CHECK(x, y);
     y -= patch->topoffset;
     x -= patch->leftoffset;
 
-    desttop = scrn + Mul320(y) + x;
+    desttop = scrn + MulScreenWidth(y) + x;
 
     w = patch->width;
 
@@ -154,24 +279,25 @@ void V_DrawPatch(int x, int y, byte *scrn, patch_t *patch)
         while (column->topdelta != 0xff)
         {
             register const byte *source = (byte *)column + 3;
-            register byte *dest = desttop + Mul320(column->topdelta);
+            register byte *dest = desttop + MulScreenWidth(column->topdelta);
             register int count = column->length;
-
+            register byte s0, s1;
             if ((count -= 4) >= 0)
                 do
                 {
-                    register byte s0, s1;
                     s0 = source[0];
                     s1 = source[1];
                     dest[0] = s0;
+                    dest[1] = s1;
                     dest[SCREENWIDTH] = s1;
                     dest += SCREENWIDTH * 2;
                     s0 = source[2];
                     s1 = source[3];
-                    source += 4;
                     dest[0] = s0;
+                    dest[1] = s1;
                     dest[SCREENWIDTH] = s1;
                     dest += SCREENWIDTH * 2;
+                    source += 4;
                 } while ((count -= 4) >= 0);
             if (count += 4)
                 do
@@ -188,25 +314,24 @@ void V_DrawPatch(int x, int y, byte *scrn, patch_t *patch)
 #if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
 void V_DrawPatchScreen0(int x, int y, patch_t *patch)
 {
-
     int count;
     int col = 0;
     column_t *column;
     byte *desttop;
     byte *dest;
     byte *source;
-    int w;
-
+    int w, i;
+    SCALED_BOUNDS_CHECK(x, y);
     y -= patch->topoffset;
     x -= patch->leftoffset;
+    SCALED_BOUNDS_CHECK(x, y);
+    V_MarkRect(x * PIXEL_SCALING, y * PIXEL_SCALING, patch->width * PIXEL_SCALING, patch->height * PIXEL_SCALING);
 
-    V_MarkRect(x, y, patch->width, patch->height);
-
-    desttop = screen0 + Mul320(y) + x;
+     desttop = screen0 + MulScreenWidth(y * PIXEL_SCALING) + x * PIXEL_SCALING;
 
     w = patch->width;
 
-    for (; col < w; x++, col++, desttop++)
+    for (; col < w; x++, col++, desttop+=PIXEL_SCALING)
     {
         column = (column_t *)((byte *)patch + patch->columnofs[col]);
 
@@ -214,13 +339,13 @@ void V_DrawPatchScreen0(int x, int y, patch_t *patch)
         while (column->topdelta != 0xff)
         {
             register const byte *source = (byte *)column + 3;
-            register byte *dest = desttop + Mul320(column->topdelta);
+            register byte *dest = desttop + MulScreenWidth(column->topdelta * PIXEL_SCALING);
             register int count = column->length;
-
+            register byte s0, s1;
+#if PIXEL_SCALING==1
             if ((count -= 4) >= 0)
                 do
                 {
-                    register byte s0, s1;
                     s0 = source[0];
                     s1 = source[1];
                     dest[0] = s0;
@@ -228,10 +353,10 @@ void V_DrawPatchScreen0(int x, int y, patch_t *patch)
                     dest += SCREENWIDTH * 2;
                     s0 = source[2];
                     s1 = source[3];
-                    source += 4;
                     dest[0] = s0;
                     dest[SCREENWIDTH] = s1;
                     dest += SCREENWIDTH * 2;
+                    source += 4;
                 } while ((count -= 4) >= 0);
             if (count += 4)
                 do
@@ -239,6 +364,52 @@ void V_DrawPatchScreen0(int x, int y, patch_t *patch)
                     *dest = *source++;
                     dest += SCREENWIDTH;
                 } while (--count);
+#elif PIXEL_SCALING==2 // HI_RES
+              if ((count -= 4) >= 0)
+                  do {
+                      s0 = source[0];
+                      s1 = source[1];
+                      dest[0] = s0;
+                      dest[1] = s0;
+                      dest += SCREENWIDTH;
+                      dest[0] = s0;
+                      dest[1] = s0;
+                      dest += SCREENWIDTH;
+                      dest[0] = s1;
+                      dest[1] = s1;
+                      dest += SCREENWIDTH;
+                      dest[0] = s1;
+                      dest[1] = s1;
+                      dest += SCREENWIDTH;
+                      s0 = source[2];
+                      s1 = source[3];
+                      dest[0] = s0;
+                      dest[1] = s0;
+                      dest += SCREENWIDTH;
+                      dest[0] = s0;
+                      dest[1] = s0;
+                      dest += SCREENWIDTH;
+                      dest[0] = s1;
+                      dest[1] = s1;
+                      dest += SCREENWIDTH;
+                      dest[0] = s1;
+                      dest[1] = s1;
+                      dest += SCREENWIDTH;
+                      source += 4;
+                  } while ((count -= 4) >= 0);
+              if (count += 4)
+                  do
+                  {
+                      s0 = *source;
+                      dest[0] = s0;
+                      dest[1] = s0;
+                      dest += SCREENWIDTH;
+                      dest[0] = s0;
+                      dest[1] = s0;
+                      dest += SCREENWIDTH;
+                      source++;
+                  } while (--count);
+#endif
             column = (column_t *)(source + 1);
         }
     }
@@ -261,18 +432,18 @@ void V_DrawPatchFlippedScreen0(int x, int y, patch_t *patch)
     byte *dest;
     byte *source;
     int w;
-
+    BOUNDS_CHECK(x, y);
     y -= patch->topoffset;
     x -= patch->leftoffset;
 
-    V_MarkRect(x, y, patch->width, patch->height);
+    V_MarkRect(x * PIXEL_SCALING, y * PIXEL_SCALING, patch->width * PIXEL_SCALING, patch->height * PIXEL_SCALING);
 
     col = 0;
-    desttop = screen0 + Mul320(y) + x;
+    desttop = screen0 + MulScreenWidth(y * PIXEL_SCALING) + x * PIXEL_SCALING;
 
     w = patch->width;
 
-    for (; col < w; x++, col++, desttop++)
+    for (; col < w; x++, col++, desttop+=PIXEL_SCALING)
     {
         column = (column_t *)((byte *)patch + patch->columnofs[w - 1 - col]);
 
@@ -280,14 +451,27 @@ void V_DrawPatchFlippedScreen0(int x, int y, patch_t *patch)
         while (column->topdelta != 0xff)
         {
             source = (byte *)column + 3;
-            dest = desttop + Mul320(column->topdelta);
+            dest = desttop + MulScreenWidth(column->topdelta * PIXEL_SCALING);
             count = column->length;
 
+#if PIXEL_SCALING==1
             while (count--)
             {
                 *dest = *source++;
                 dest += SCREENWIDTH;
             }
+#elif PIXEL_SCALING==2
+            while (count--)
+            {
+                register byte s = *source++;
+                dest[0] = s;
+                dest[1] = s;
+                dest += SCREENWIDTH;
+                dest[0] = s;
+                dest[1] = s;
+                dest += SCREENWIDTH;
+            }
+#endif
             column = (column_t *)((byte *)column + column->length + 4);
         }
     }
@@ -401,22 +585,35 @@ void V_DrawPatchDirect(int x, int y, patch_t *patch)
     x -= patch->leftoffset;
 
     col = 0;
-    desttop = destscreen + Mul320(y) + x;
+    desttop = destscreen + MulScreenWidth(y * PIXEL_SCALING) + x * PIXEL_SCALING;
     w = patch->width;
-    for (; col < w; x++, col++, desttop++)
+    for (; col < w; x++, col++, desttop+=PIXEL_SCALING)
     {
         column = (column_t *)((byte *)patch + patch->columnofs[col]);
         // Step through the posts in a column
         while (column->topdelta != 0xff)
         {
             source = (byte *)column + 3;
-            dest = desttop + Mul320(column->topdelta);
+            dest = desttop + MulScreenWidth(column->topdelta * PIXEL_SCALING);
             count = column->length;
+#if PIXEL_SCALING==1
             while (count--)
             {
                 *dest = *source++;
                 dest += SCREENWIDTH;
             }
+#elif PIXEL_SCALING==2
+            while (count--)
+            {
+                register byte s = *source++;
+                dest[0] = s;
+                dest[1] = s;
+                dest += SCREENWIDTH;
+                dest[0] = s;
+                dest[1] = s;
+                dest += SCREENWIDTH;
+            }
+#endif
             column = (column_t *)((byte *)column + column->length + 4);
         }
     }
@@ -433,7 +630,7 @@ void V_DrawPatchDirect(int x, int y, patch_t *patch)
     byte *dest;
     byte *source;
     int w;
-
+    BOUNDS_CHECK(x, y);
     y -= patch->topoffset;
     x -= patch->leftoffset;
 
@@ -498,9 +695,9 @@ void V_DrawPatchDirect(int x, int y, patch_t *patch)
     x -= patch->leftoffset;
 
     col = 0;
-    desttop = backbuffer + Mul320(y) + x;
+    desttop = backbuffer + MulScreenWidth(y * PIXEL_SCALING) + x * PIXEL_SCALING;
     w = patch->width;
-    for (; col < w; x++, col++, desttop++)
+    for (; col < w; x++, col++, desttop+=PIXEL_SCALING)
     {
 #if defined(MODE_CGA16) || defined(MODE_CVBS)
     if ((int)desttop & 1)
@@ -526,13 +723,26 @@ void V_DrawPatchDirect(int x, int y, patch_t *patch)
         while (column->topdelta != 0xff)
         {
             source = (byte *)column + 3;
-            dest = desttop + Mul320(column->topdelta);
+            dest = desttop + MulScreenWidth(column->topdelta * PIXEL_SCALING);
             count = column->length;
+#if PIXEL_SCALING==1
             while (count--)
             {
                 *dest = *source++;
                 dest += SCREENWIDTH;
             }
+#elif PIXEL_SCALING==2
+            while (count--)
+            {
+                register byte s = *source++;
+                dest[0] = s;
+                dest[1] = s;
+                dest += SCREENWIDTH;
+                dest[0] = s;
+                dest[1] = s;
+                dest += SCREENWIDTH;
+            }
+#endif
             column = (column_t *)((byte *)column + column->length + 4);
         }
     }

--- a/FASTDOOM/v_video.c
+++ b/FASTDOOM/v_video.c
@@ -29,6 +29,7 @@
 #include "m_misc.h"
 
 #include "v_video.h"
+#include "i_debug.h"
 
 #if defined(TEXT_MODE)
 #include "i_text.h"
@@ -120,11 +121,13 @@ void V_CopyRect(int srcx, int srcy, byte *srcscrn, int width, int height, int de
     }
 }
 
+
 //
 // V_DrawPatch
 // Masks a column based masked pic to the screen.
 //
 #if defined(MODE_Y) || defined(USE_BACKBUFFER) || defined(MODE_VBE2_DIRECT)
+#include "i_debug.h"
 void V_DrawPatch(int x, int y, byte *scrn, patch_t *patch)
 {
 

--- a/FASTDOOM/v_video.h
+++ b/FASTDOOM/v_video.h
@@ -44,7 +44,9 @@ extern byte screen0[SCREENWIDTH * SCREENHEIGHT];
 #endif
 
 #if defined(MODE_Y) || defined(USE_BACKBUFFER) || defined(MODE_VBE2_DIRECT)
-extern byte screen4[SCREENWIDTH * 32];
+// Note must be screenwdith because the draw functions assume this.
+// We can also expand the staus bar with this to go the full width.
+extern byte screen4[SCREENWIDTH * SBARHEIGHT];
 #endif
 
 #if defined(USE_BACKBUFFER)
@@ -67,17 +69,75 @@ void V_Init(void);
 void V_CopyRect(int srcx, int srcy, byte *srcscrn, int width, int height, int destx, int desty, byte *destscrn);
 
 void V_DrawPatch(int x, int y, byte *scrn, patch_t *patch);
-void V_DrawPatchScreen0(int x, int y, patch_t *patch);
-void V_DrawPatchDirect(int x, int y, patch_t *patch);
-void V_DrawPatchFlippedScreen0(int x, int y, patch_t *patch);
 
+#if PIXEL_SCALING!=1
+// If we are pixel scaling, we need a version of V_DrawPatch that draws to the
+// native resolution. This is currently only used for the border texture.
+void V_DrawPatchNativeRes(int x, int y, byte *scrn, patch_t *patch);
+#else
+// V_DrawPatchNativeRes is just an alias for V_DrawPatch.
+#define V_DrawPatchNativeRes(x, y, scrn, patch) V_DrawPatch(x, y, scrn, patch)
+#endif
+
+// Begin mode specific functions.
+
+#if defined(MODE_T4050)
 void V_DrawPatchDirectText4050(int x, int y, patch_t *patch);
-void V_DrawPatchDirectText4025(int x, int y, patch_t *patch);
-void V_DrawPatchDirectText8025(int x, int y, patch_t *patch);
-void V_DrawPatchDirectText8043(int x, int y, patch_t *patch);
-void V_DrawPatchDirectText8050(int x, int y, patch_t *patch);
-void V_DrawPatchDirectTextMDA(int x, int y, patch_t *patch);
+#define V_DrawPatchMode V_DrawPatchDirectText4050
+#endif
 
+#if defined(MODE_T4025)
+void V_DrawPatchDirectText4025(int x, int y, patch_t *patch);
+#define V_DrawPatchMode V_DrawPatchDirectText4025
+#endif
+
+#if defined(MODE_T8025)
+void V_DrawPatchDirectText8025(int x, int y, patch_t *patch);
+#define V_DrawPatchMode V_DrawPatchDirectText8025
+#endif
+
+#if defined(MODE_T8043)
+void V_DrawPatchDirectText8043(int x, int y, patch_t *patch);
+#define V_DrawPatchMode V_DrawPatchDirectText8043
+#endif
+
+#if defined(MODE_T8050)
+void V_DrawPatchDirectText8050(int x, int y, patch_t *patch);
+#define V_DrawPatchMode V_DrawPatchDirectText8050
+#endif
+
+#if defined(MODE_MDA)
+void V_DrawPatchDirectTextMDA(int x, int y, patch_t *patch);
+#define V_DrawPatchMode V_DrawPatchDirectTextMDA
+#endif
+
+#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT) || defined(USE_BACKBUFFER)
+void V_DrawPatchDirect(int x, int y, patch_t *patch);
+#define V_DrawPatchDirectCentered(x, y, patch) \
+  V_DrawPatchDirect(CENTERING_OFFSET_X + (x), CENTERING_OFFSET_Y + (y), patch)
+void V_DrawPatchFlippedDirect(int x, int y, patch_t *patch);
+#endif
+
+#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
+void V_DrawPatchScreen0(int x, int y, patch_t *patch);
+void V_DrawPatchFlippedScreen0(int x, int y, patch_t *patch);
+#define V_DrawPatchMode V_DrawPatchScreen0
+#define V_DrawPatchFlippedMode V_DrawPatchFlippedScreen0
+#endif
+
+#if defined(USE_BACKBUFFER)
+#define V_DrawPatchMode V_DrawPatchDirect
+// TODO SHould there be a flipped mode PatchDirect?
+#define V_DrawPatchFlippedMode V_DrawPatchDirect
+#endif
+
+#define V_DrawPatchModeCentered(x, y, patch) \
+  V_DrawPatchMode(CENTERING_OFFSET_X + (x), CENTERING_OFFSET_Y + (y), patch)
+#define V_DrawPatchFlippedModeCentered(x, y, patch) \
+  V_DrawPatchFlippedMode(CENTERING_OFFSET_X + (x), CENTERING_OFFSET_Y + (y), patch)
+
+// End mode specific functions.
+//
 void V_WriteTextDirect(int x, int y, char *string);
 void V_WriteCharDirect(int x, int y, unsigned char c);
 

--- a/FASTDOOM/vbe2dh.asm
+++ b/FASTDOOM/vbe2dh.asm
@@ -61,12 +61,12 @@ CODE_SYM_DEF R_DrawColumnVBE2
 
   mov  ebp,[_dc_yh]
   mov  eax,[_dc_yl]
-  lea  edi,[ebp+ebp*4]
+  MulScreenWidthStart edi, ebp
   sub  ebp,eax ; ebp = pixel count
   js   near .done
 
   mov  ebx,[_dc_x]
-  shl  edi,6
+  MulScreenWidthEnd edi
   mov  ecx,[_dc_iscale]
   add  edi,ebx
   add  edi,[_destview]
@@ -174,15 +174,15 @@ CODE_SYM_DEF R_DrawSpanVBE2
 
   mov  ebp,[_ds_y]
   mov  eax,[_ds_colormap]
-  lea  edi,[ebp+ebp*4]
+  MulScreenWidthStart edi, ebp
   shld  ebx,ecx,22      ; shift y units in
-  shl  edi,6
+  MulScreenWidthEnd edi
   mov   ebp,0x0FFF  ; used to mask off slop high bits from position
   add  edi,[_destview]
   shld  ebx,ecx,6       ; shift x units in
   and   ebx,ebp         ; mask off slop bits
   add   ecx,edx
-  
+
   ; feed the pipeline and jump in
   call  [callpoint]
 
@@ -211,7 +211,7 @@ CODE_SYM_DEF R_DrawSpanVBE2
   %rep 4
     MAPLABEL LINE:
       %assign LINE LINE+1
-      %if LINE = 320
+      %if LINE = SCREENWIDTH/4
         mov   al,[esi+ebx]           ; get source pixel
         mov   al,[eax]               ; translate color
         mov   [edi+PLANE+PCOL*4],al  ; write pixel
@@ -229,7 +229,7 @@ CODE_SYM_DEF R_DrawSpanVBE2
 %assign PCOL PCOL+1
 %endrep
 
-hmap320:
+MAPLABEL LINE:
   ret
 
 %endif

--- a/FASTDOOM/vbe2dh2.asm
+++ b/FASTDOOM/vbe2dh2.asm
@@ -73,12 +73,12 @@ CODE_SYM_DEF R_DrawFuzzColumnVBE2
 
   cmp  eax,1
   adc  eax,0
-  
-  lea  edi,[ebp+ebp*4]
+
+  MulScreenWidthStart edi, ebp
   sub  ebp,eax ; ebp = pixel count
   js   near .done
 
-  shl  edi,6
+  MulScreenWidthEnd edi
   add  edi,[_dc_x]
   add  edi,[_destview]
 
@@ -120,13 +120,13 @@ CODE_SYM_DEF R_DrawFuzzColumnVBE2
 %rep SCREENHEIGHT
   SCALELABEL LINE:
   mov		ebp,[edx+ecx*4]
-	mov   al,[ebp+edi-(LINE-1)*320]
+	mov   al,[ebp+edi-(LINE-1)*SCREENWIDTH]
   dec   ecx
 	mov		al,[eax]
   JMPTESTFUZZPOSDEFINE LINE
   mov   ecx,ebx
   TESTFUZZPOSDEFINE LINE:
-  mov		[edi-(LINE-1)*320],al
+  mov		[edi-(LINE-1)*SCREENWIDTH],al
   %assign LINE LINE-1
 %endrep
 

--- a/FASTDOOM/vbe2dh3.asm
+++ b/FASTDOOM/vbe2dh3.asm
@@ -61,11 +61,12 @@ CODE_SYM_DEF R_DrawFuzzColumnFlatVBE2
 
   mov  ebp,[_dc_yh]
   mov  eax,[_dc_yl]
-  lea  edi,[ebp+ebp*4]
+
+  MulScreenWidthStart edi, ebp
   sub  ebp,eax ; ebp = pixel count
   js   near .done
 
-  shl  edi,6
+  MulScreenWidthEnd edi
   add  edi,[_dc_x]
   add  edi,[_destview]
 
@@ -94,21 +95,21 @@ CODE_SYM_DEF R_DrawFuzzColumnFlatVBE2
 %rep SCREENHEIGHT-1
   SCALELABEL LINE:
 
-	mov   al,[edi-(LINE-1)*320]
+	mov   al,[edi-(LINE-1)*SCREENWIDTH]
 	mov		al,[eax]
-  mov		[edi-(LINE-1)*320],al
+  mov		[edi-(LINE-1)*SCREENWIDTH],al
 
   %assign LINE LINE-1
 %endrep
 
 vscale1:
 	pop	ebp
-  mov   al,[edi-(LINE-1)*320]
+  mov   al,[edi-(LINE-1)*SCREENWIDTH]
   pop	esi
 	mov		al,[eax]
   pop	edx
-  mov		[edi-(LINE-1)*320],al
-  
+  mov		[edi-(LINE-1)*SCREENWIDTH],al
+
 vscale0:
 	pop	ecx
 	pop	ebx

--- a/FASTDOOM/vbe2dhSX.asm
+++ b/FASTDOOM/vbe2dhSX.asm
@@ -57,9 +57,9 @@ CODE_SYM_DEF R_DrawSpanVBE2_386SX
 
   mov  ebp,[_ds_y]
   mov  eax,[_ds_colormap]
-  lea  edi,[ebp+ebp*4]
+  MulScreenWidthStart edi, ebp
   shld  ebx,ecx,22      ; shift y units in
-  shl  edi,6
+  MulScreenWidthEnd edi
   mov   ebp,0x0FFF  ; used to mask off slop high bits from position
   add  edi,[_destview]
   shld  ebx,ecx,6       ; shift x units in
@@ -94,7 +94,7 @@ CODE_SYM_DEF R_DrawSpanVBE2_386SX
   %rep 4
     MAPLABEL LINE:
       %assign LINE LINE+1
-      %if LINE = 320
+      %if LINE = SCREENWIDTH/4
         mov   al,[esi+ebx]           ; get source pixel
         mov   al,[eax]               ; translate color
         mov   [edi+PLANE+PCOL*4],al  ; write pixel
@@ -112,7 +112,7 @@ CODE_SYM_DEF R_DrawSpanVBE2_386SX
 %assign PCOL PCOL+1
 %endrep
 
-hmap320:
+MAPLABEL LINE:
   ret
 
 %endif

--- a/FASTDOOM/vbe2dl.asm
+++ b/FASTDOOM/vbe2dl.asm
@@ -61,12 +61,12 @@ CODE_SYM_DEF R_DrawColumnLowVBE2
 
   mov  ebp,[_dc_yh]
   mov  eax,[_dc_yl]
-  lea  edi,[ebp+ebp*4]
+  MulScreenWidthStart edi, ebp
   sub  ebp,eax ; ebp = pixel count
   js   near .done
 
+  MulScreenWidthEnd edi
   mov  ebx,[_dc_x]
-  shl  edi,6
   mov  ecx,[_dc_iscale]
   lea  edi,[edi+ebx*2]
   sub  eax,[_centery]
@@ -176,9 +176,9 @@ CODE_SYM_DEF R_DrawSpanLowVBE2
 
   mov  edx,[_ds_y]
   mov  eax,[_ds_colormap]
-  lea  edi,[edx+edx*4]
+  MulScreenWidthStart edi, edx
   shld  ebx,ecx,22      ; shift y units in
-  shl  edi,6
+  MulScreenWidthEnd edi
   add  edi,[_destview]
   shld  ebx,ecx,6       ; shift x units in
   xor   edx,edx
@@ -212,7 +212,7 @@ CODE_SYM_DEF R_DrawSpanLowVBE2
   %assign PLANE 0
     MAPLABEL LINE:
       %assign LINE LINE+1
-      %if LINE = 160
+      %if LINE = SCREENWIDTH/2
         mov   al,[esi+ebx]           ; get source pixel
         mov   al,[eax]               ; translate color
         mov   ah,al
@@ -231,7 +231,7 @@ CODE_SYM_DEF R_DrawSpanLowVBE2
 %assign PCOL PCOL+1
 %endrep
 
-hmap160:
+MAPLABEL LINE:
   ret
 
 %endif

--- a/FASTDOOM/vbe2dl2.asm
+++ b/FASTDOOM/vbe2dl2.asm
@@ -73,12 +73,12 @@ CODE_SYM_DEF R_DrawFuzzColumnLowVBE2
 
   cmp  eax,1
   adc  eax,0
-  
-  lea  edi,[ebp+ebp*4]
+
+  MulScreenWidthStart edi,ebp
   sub  ebp,eax ; ebp = pixel count
   js   near .done
 
-  shl  edi,6
+  MulScreenWidthEnd edi
   mov  eax,[_dc_x]
   mov	ecx,[_fuzzposinverse]
   lea  edi,[edi+eax*2]
@@ -120,14 +120,14 @@ CODE_SYM_DEF R_DrawFuzzColumnLowVBE2
 %rep SCREENHEIGHT
   SCALELABEL LINE:
   mov		ebp,[edx+ecx*4]
-	mov   al,[ebp+edi-(LINE-1)*320]
+	mov   al,[ebp+edi-(LINE-1)*SCREENWIDTH]
   dec   ecx
 	mov		bl,[eax]
   JMPTESTFUZZPOSDEFINE LINE
   mov   ecx,esi
   TESTFUZZPOSDEFINE LINE:
   mov   bh,bl
-  mov		[edi-(LINE-1)*320],bx
+  mov		[edi-(LINE-1)*SCREENWIDTH],bx
   %assign LINE LINE-1
 %endrep
 

--- a/FASTDOOM/vbe2dl3.asm
+++ b/FASTDOOM/vbe2dl3.asm
@@ -61,11 +61,11 @@ CODE_SYM_DEF R_DrawFuzzColumnFlatLowVBE2
 
   mov  ebp,[_dc_yh]
   mov  eax,[_dc_yl]
-  lea  edi,[ebp+ebp*4]
+  MulScreenWidthStart edi, ebp
   sub  ebp,eax ; ebp = pixel count
   js   near .done
 
-  shl  edi,6
+  MulScreenWidthEnd edi
   mov  eax,[_dc_x]
   xor ecx,ecx
   lea  edi,[edi+eax*2]
@@ -95,22 +95,22 @@ CODE_SYM_DEF R_DrawFuzzColumnFlatLowVBE2
 %rep SCREENHEIGHT-1
   SCALELABEL LINE:
 
-	mov   al,[edi-(LINE-1)*320]
+	mov   al,[edi-(LINE-1)*SCREENWIDTH]
 	mov		cl,[eax]
   mov   ch,cl
-  mov		[edi-(LINE-1)*320],cx
+  mov		[edi-(LINE-1)*SCREENWIDTH],cx
 
   %assign LINE LINE-1
 %endrep
 
 vscale1:
-  mov   al,[edi-(LINE-1)*320]
+  mov   al,[edi-(LINE-1)*SCREENWIDTH]
 	pop	ebp
 	mov		cl,[eax]
   pop	esi
   mov   ch,cl
   pop	edx
-  mov		[edi-(LINE-1)*320],cx
+  mov		[edi-(LINE-1)*SCREENWIDTH],cx
 
 vscale0:
 	pop	ecx

--- a/FASTDOOM/vbe2dlSX.asm
+++ b/FASTDOOM/vbe2dlSX.asm
@@ -57,9 +57,9 @@ CODE_SYM_DEF R_DrawSpanLowVBE2_386SX
 
   mov  edx,[_ds_y]
   mov  eax,[_ds_colormap]
-  lea  edi,[edx+edx*4]
+  MulScreenWidthStart edi, edx
   shld  ebx,ecx,22      ; shift y units in
-  shl  edi,6
+  MulScreenWidthEnd edi
   add  edi,[_destview]
   shld  ebx,ecx,6       ; shift x units in
   xor   edx,edx
@@ -93,7 +93,7 @@ CODE_SYM_DEF R_DrawSpanLowVBE2_386SX
   %assign PLANE 0
     MAPLABEL LINE:
       %assign LINE LINE+1
-      %if LINE = 160
+      %if LINE = SCREENWIDTH/2
         mov   al,[esi+ebx]           ; get source pixel
         mov   al,[eax]               ; translate color
         mov   ah,al
@@ -112,7 +112,7 @@ CODE_SYM_DEF R_DrawSpanLowVBE2_386SX
 %assign PCOL PCOL+1
 %endrep
 
-hmap160:
+MAPLABEL LINE:
   ret
 
 %endif

--- a/FASTDOOM/vbe2dp.asm
+++ b/FASTDOOM/vbe2dp.asm
@@ -61,12 +61,12 @@ CODE_SYM_DEF R_DrawColumnPotatoVBE2
 
   mov  ebp,[_dc_yh]
   mov  eax,[_dc_yl]
-  lea  edi,[ebp+ebp*4]
+  MulScreenWidthStart edi, ebp
   sub  ebp,eax ; ebp = pixel count
   js   near .done
 
   mov  ebx,[_dc_x]
-  shl  edi,6
+  MulScreenWidthEnd edi
   mov  ecx,[_dc_iscale]
   lea  edi,[edi+ebx*4]
   sub  eax,[_centery]
@@ -178,9 +178,9 @@ CODE_SYM_DEF R_DrawSpanPotatoVBE2
 
   mov  edx,[_ds_y]
   mov  eax,[_ds_colormap]
-  lea  edi,[edx+edx*4]
+  MulScreenWidthStart edi, edx
   shld  ebx,ecx,22      ; shift y units in
-  shl  edi,6
+  MulScreenWidthEnd edi
   add  edi,[_destview]
   shld  ebx,ecx,6       ; shift x units in
   xor     edx,edx
@@ -214,7 +214,7 @@ CODE_SYM_DEF R_DrawSpanPotatoVBE2
   %assign PLANE 0
     MAPLABEL LINE:
       %assign LINE LINE+1
-      %if LINE = 80
+      %if LINE = SCREENWIDTH/4
         mov   al,[esi+ebx]           ; get source pixel
         mov   al,[eax]               ; translate color
         mov   ah,al
@@ -226,7 +226,7 @@ CODE_SYM_DEF R_DrawSpanPotatoVBE2
         mov   dl,[eax]               ; translate color
         shld  ebx,ecx,6              ; shift x units in
         mov   dh,dl
-        mov   [edi+PLANE+PCOL*4],dx  ; write pixel        
+        mov   [edi+PLANE+PCOL*4],dx  ; write pixel
         mov   [edi+PLANE+PCOL*4+2],dx  ; write pixel
         and   ebx,0x0FFF             ; mask off slop bits
         add   ecx,ebp                ; position += step
@@ -235,6 +235,7 @@ CODE_SYM_DEF R_DrawSpanPotatoVBE2
 %assign PCOL PCOL+1
 %endrep
 
-hmap80: ret
+MAPLABEL LINE:
+  rep
 
 %endif

--- a/FASTDOOM/vbe2dp2.asm
+++ b/FASTDOOM/vbe2dp2.asm
@@ -77,13 +77,13 @@ CODE_SYM_DEF R_DrawFuzzColumnPotatoVBE2
 
   cmp  eax,1
   adc  eax,0
-  
-  lea  edi,[ebp+ebp*4]
+
+  MulScreenWidthStart edi, ebp
   sub  ebp,eax ; ebp = pixel count
   js   near .done
 
   mov  eax,[_dc_x]
-  shl  edi,6
+  MulScreenWidthEnd edi
   xor ebx,ebx
   lea  edi,[edi+eax*4]
   mov eax,[_colormaps]
@@ -124,15 +124,15 @@ CODE_SYM_DEF R_DrawFuzzColumnPotatoVBE2
 %rep SCREENHEIGHT
   SCALELABEL LINE:
   mov		ebp,[edx+ecx*4]
-	mov   al,[ebp+edi-(LINE-1)*320]
+	mov   al,[ebp+edi-(LINE-1)*SCREENWIDTH]
   dec   ecx
 	mov		bl,[eax]
   JMPTESTFUZZPOSDEFINE LINE
   mov   ecx,esi
   TESTFUZZPOSDEFINE LINE:
   mov   bh,bl
-  mov		[edi-(LINE-1)*320],bx
-  mov		[edi-(LINE-1)*320+2],bx
+  mov		[edi-(LINE-1)*SCREENWIDTH],bx
+  mov		[edi-(LINE-1)*SCREENWIDTH+2],bx
   %assign LINE LINE-1
 %endrep
 

--- a/FASTDOOM/vbe2dp3.asm
+++ b/FASTDOOM/vbe2dp3.asm
@@ -61,12 +61,12 @@ CODE_SYM_DEF R_DrawFuzzColumnFlatPotatoVBE2
 
   mov  ebp,[_dc_yh]
   mov  eax,[_dc_yl]
-  lea  edi,[ebp+ebp*4]
+  MulScreenWidthStart edi, ebp
   sub  ebp,eax ; ebp = pixel count
   js   near .done
 
   mov  eax,[_dc_x]
-  shl  edi,6
+  MulScreenWidthEnd edi
   xor  ecx,ecx
   lea  edi,[edi+eax*4]
   add  edi,[_destview]
@@ -96,25 +96,25 @@ CODE_SYM_DEF R_DrawFuzzColumnFlatPotatoVBE2
 %rep SCREENHEIGHT-1
   SCALELABEL LINE:
 
-	mov   al,[edi-(LINE-1)*320]
+	mov   al,[edi-(LINE-1)*SCREENWIDTH]
 	mov		cl,[eax]
   mov   ch,cl
-  mov		[edi-(LINE-1)*320],cx
-  mov		[edi-(LINE-1)*320+2],cx
+  mov		[edi-(LINE-1)*SCREENWIDTH],cx
+  mov		[edi-(LINE-1)*SCREENWIDTH+2],cx
 
   %assign LINE LINE-1
 %endrep
 
 vscale1:
-  mov   al,[edi-(LINE-1)*320]
+  mov   al,[edi-(LINE-1)*SCREENWIDTH]
 	pop	ebp
 	mov		cl,[eax]
   pop	esi
   mov   ch,cl
   pop	edx
-  mov		[edi-(LINE-1)*320],cx
-  mov		[edi-(LINE-1)*320+2],cx
-  
+  mov		[edi-(LINE-1)*SCREENWIDTH],cx
+  mov		[edi-(LINE-1)*SCREENWIDTH+2],cx
+
 vscale0:
 	pop	ecx
 	pop	ebx

--- a/FASTDOOM/vbe2dpSX.asm
+++ b/FASTDOOM/vbe2dpSX.asm
@@ -57,9 +57,9 @@ CODE_SYM_DEF R_DrawSpanPotatoVBE2_386SX
 
   mov  edx,[_ds_y]
   mov  eax,[_ds_colormap]
-  lea  edi,[edx+edx*4]
+  MulScreenWidthStart edi,edx
   shld  ebx,ecx,22      ; shift y units in
-  shl  edi,6
+  MulScreenWidthEnd edi
   add  edi,[_destview]
   shld  ebx,ecx,6       ; shift x units in
   xor     edx,edx
@@ -93,7 +93,7 @@ CODE_SYM_DEF R_DrawSpanPotatoVBE2_386SX
   %assign PLANE 0
     MAPLABEL LINE:
       %assign LINE LINE+1
-      %if LINE = 80
+      %if LINE = SCREENWIDTH/4
         mov   al,[esi+ebx]           ; get source pixel
         mov   al,[eax]               ; translate color
         mov   ah,al
@@ -114,6 +114,6 @@ CODE_SYM_DEF R_DrawSpanPotatoVBE2_386SX
 %assign PCOL PCOL+1
 %endrep
 
-hmap80: ret
+MAPLABEL LINE:
 
 %endif

--- a/FASTDOOM/vga13h.asm
+++ b/FASTDOOM/vga13h.asm
@@ -28,7 +28,7 @@ BEGIN_DATA_SECTION
 
 align 4
 
-_vrambuffer: times 64000 db 0
+_vrambuffer: times 320 * 200 db 0
 
 BEGIN_CODE_SECTION
 

--- a/FASTDOOM/wi_stuff.c
+++ b/FASTDOOM/wi_stuff.c
@@ -77,7 +77,7 @@
 #define SP_STATSY 50
 
 #define SP_TIMEX 16
-#define SP_TIMEY (SCREENHEIGHT - 32)
+#define SP_TIMEY (200 - 32)
 
 typedef enum
 {
@@ -401,38 +401,31 @@ void WI_drawLF(void)
 	// draw <LevelName>
 
 #if defined(MODE_T4025) || defined(MODE_T4050)
-	V_WriteTextDirect((SCREENWIDTH - lnames[wbs->last]->width) / 16, y / 8, titlecurrent);
+	V_WriteTextDirect((320 - lnames[wbs->last]->width) / 16, y / 8, titlecurrent);
 #endif
 #if defined(MODE_T8025) || defined(MODE_MDA)
-	V_WriteTextDirect((SCREENWIDTH - lnames[wbs->last]->width) / 8, y / 8, titlecurrent);
+	V_WriteTextDirect((320 - lnames[wbs->last]->width) / 8, y / 8, titlecurrent);
 #endif
 #if defined(MODE_T8050) || defined(MODE_T8043)
-	V_WriteTextDirect((SCREENWIDTH - lnames[wbs->last]->width) / 8, y / 4, titlecurrent);
+	V_WriteTextDirect((320 - lnames[wbs->last]->width) / 8, y / 4, titlecurrent);
 #endif
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-	V_DrawPatchScreen0((SCREENWIDTH - lnames[wbs->last]->width) / 2, y, lnames[wbs->last]);
+#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT) || defined(USE_BACKBUFFER)
+  V_DrawPatchModeCentered((320 - lnames[wbs->last]->width) / 2, y, lnames[wbs->last]);
 #endif
-#if defined(USE_BACKBUFFER)
-	V_DrawPatchDirect((SCREENWIDTH - lnames[wbs->last]->width) / 2, y, lnames[wbs->last]);
-#endif
-
 	// draw "Finished!"
 	y += (5 * lnames[wbs->last]->height) / 4;
 
 #if defined(MODE_T4025) || defined(MODE_T4050)
-	V_WriteTextDirect((SCREENWIDTH - finished->width) / 16, y / 8, "FINISHED");
+	V_WriteTextDirect((320 - finished->width) / 16, y / 8, "FINISHED");
 #endif
 #if defined(MODE_T8025) || defined(MODE_MDA)
-	V_WriteTextDirect((SCREENWIDTH - finished->width) / 8, y / 8, "FINISHED");
+	V_WriteTextDirect((320 - finished->width) / 8, y / 8, "FINISHED");
 #endif
 #if defined(MODE_T8050) || defined(MODE_T8043)
-	V_WriteTextDirect((SCREENWIDTH - finished->width) / 8, y / 4, "FINISHED");
+	V_WriteTextDirect((320 - finished->width) / 8, y / 4, "FINISHED");
 #endif
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-	V_DrawPatchScreen0((SCREENWIDTH - finished->width) / 2, y, finished);
-#endif
-#if defined(USE_BACKBUFFER)
-	V_DrawPatchDirect((SCREENWIDTH - finished->width) / 2, y, finished);
+#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT) || defined(USE_BACKBUFFER)
+  V_DrawPatchModeCentered((320 - finished->width) / 2, y, finished);
 #endif
 }
 
@@ -473,38 +466,32 @@ void WI_drawEL(void)
 
 // draw "Entering"
 #if defined(MODE_T4025) || defined(MODE_T4050)
-	V_WriteTextDirect((SCREENWIDTH - entering->width) / 16, y / 8, "ENTERING");
+	V_WriteTextDirect((320 - entering->width) / 16, y / 8, "ENTERING");
 #endif
 #if defined(MODE_T8025) || defined(MODE_MDA)
-	V_WriteTextDirect((SCREENWIDTH - entering->width) / 8, y / 8, "ENTERING");
+	V_WriteTextDirect((320 - entering->width) / 8, y / 8, "ENTERING");
 #endif
 #if defined(MODE_T8050) || defined(MODE_T8043)
-	V_WriteTextDirect((SCREENWIDTH - entering->width) / 8, y / 4, "ENTERING");
+	V_WriteTextDirect((320 - entering->width) / 8, y / 4, "ENTERING");
 #endif
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-	V_DrawPatchScreen0((SCREENWIDTH - entering->width) / 2, y, entering);
-#endif
-#if defined(USE_BACKBUFFER)
-	V_DrawPatchDirect((SCREENWIDTH - entering->width) / 2, y, entering);
+#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT) || defined(USE_BACKBUFFER)
+  V_DrawPatchModeCentered((320 - entering->width) / 2, y, entering);
 #endif
 
 	// draw level
 	y += (5 * lnames[wbs->next]->height) / 4;
 
 #if defined(MODE_T4025) || defined(MODE_T4050)
-	V_WriteTextDirect((SCREENWIDTH - lnames[wbs->next]->width) / 16, y / 8, titlenext);
+	V_WriteTextDirect((320 - lnames[wbs->next]->width) / 16, y / 8, titlenext);
 #endif
 #if defined(MODE_T8025) || defined(MODE_MDA)
-	V_WriteTextDirect((SCREENWIDTH - lnames[wbs->next]->width) / 8, y / 8, titlenext);
+	V_WriteTextDirect((320 - lnames[wbs->next]->width) / 8, y / 8, titlenext);
 #endif
 #if defined(MODE_T8050) || defined(MODE_T8043)
-	V_WriteTextDirect((SCREENWIDTH - lnames[wbs->next]->width) / 8, y / 4, titlenext);
+	V_WriteTextDirect((320 - lnames[wbs->next]->width) / 8, y / 4, titlenext);
 #endif
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-	V_DrawPatchScreen0((SCREENWIDTH - lnames[wbs->next]->width) / 2, y, lnames[wbs->next]);
-#endif
-#if defined(USE_BACKBUFFER)
-	V_DrawPatchDirect((SCREENWIDTH - lnames[wbs->next]->width) / 2, y, lnames[wbs->next]);
+#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT) || defined(USE_BACKBUFFER)
+  V_DrawPatchModeCentered((320 - lnames[wbs->next]->width) / 2, y, lnames[wbs->next]);
 #endif
 }
 
@@ -527,7 +514,7 @@ void WI_drawOnLnode(int n, patch_t *c[])
 		right = left + c[i]->width;
 		bottom = top + c[i]->height;
 
-		if (left >= 0 && right < SCREENWIDTH && top >= 0 && bottom < SCREENHEIGHT)
+		if (left >= 0 && right < 320 && top >= 0 && bottom < SCALED_SCREENHEIGHT)
 		{
 			fits = 1;
 		}
@@ -539,12 +526,7 @@ void WI_drawOnLnode(int n, patch_t *c[])
 
 	if (fits && i < 2)
 	{
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-		V_DrawPatchScreen0(lnodes[wbs->epsd][n].x, lnodes[wbs->epsd][n].y, c[i]);
-#endif
-#if defined(USE_BACKBUFFER)
-		V_DrawPatchDirect(lnodes[wbs->epsd][n].x, lnodes[wbs->epsd][n].y, c[i]);
-#endif
+    V_DrawPatchModeCentered(lnodes[wbs->epsd][n].x, lnodes[wbs->epsd][n].y, c[i]);
 	}
 }
 #endif
@@ -632,11 +614,8 @@ void WI_drawAnimatedBack(void)
 
 		if (a->ctr >= 0)
 		{
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-			V_DrawPatchScreen0(a->loc.x, a->loc.y, a->p[a->ctr]);
-#endif
-#if defined(USE_BACKBUFFER)
-			V_DrawPatchDirect(a->loc.x, a->loc.y, a->p[a->ctr]);
+#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT) || defined(USE_BACKBUFFER)
+      V_DrawPatchModeCentered(a->loc.x, a->loc.y, a->p[a->ctr]);
 #endif
 		}
 	}
@@ -694,21 +673,15 @@ int WI_drawNumTwoDigits(int x, int y, int n)
 	original = n;
 	n = Div10(n);
 	x -= fontwidth;
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-	V_DrawPatchScreen0(x, y, num[original - Mul10(n)]);
-#endif
-#if defined(USE_BACKBUFFER)
-	V_DrawPatchDirect(x, y, num[original - Mul10(n)]);
+#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT) || defined(USE_BACKBUFFER)
+	V_DrawPatchModeCentered(x, y, num[original - Mul10(n)]);
 #endif
 
 	original = n;
 	n = Div10(n);
 	x -= fontwidth;
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-	V_DrawPatchScreen0(x, y, num[original - Mul10(n)]);
-#endif
-#if defined(USE_BACKBUFFER)
-	V_DrawPatchDirect(x, y, num[original - Mul10(n)]);
+#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT) || defined(USE_BACKBUFFER)
+	V_DrawPatchModeCentered(x, y, num[original - Mul10(n)]);
 #endif
 
 	return x;
@@ -732,11 +705,8 @@ int WI_drawNum(int x, int y, int n)
 
 		n = Div10(n);
 		x -= fontwidth;
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-		V_DrawPatchScreen0(x, y, num[original - Mul10(n)]);
-#endif
-#if defined(USE_BACKBUFFER)
-		V_DrawPatchDirect(x, y, num[original - Mul10(n)]);
+#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT) || defined(USE_BACKBUFFER)
+		V_DrawPatchModeCentered(x, y, num[original - Mul10(n)]);
 #endif
 	} while (n);
 
@@ -765,12 +735,8 @@ void WI_drawPercent(int x, int y, int p)
 	sprintf(strnum, "%i%%", p);
 	V_WriteTextDirect(x / 2, y / 4 - 1, strnum);
 #endif
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-	V_DrawPatchScreen0(x, y, percent);
-	WI_drawNum(x, y, p);
-#endif
-#if defined(USE_BACKBUFFER)
-	V_DrawPatchDirect(x, y, percent);
+#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT) || defined(USE_BACKBUFFER)
+  V_DrawPatchModeCentered(x, y, percent);
 	WI_drawNum(x, y, p);
 #endif
 }
@@ -813,11 +779,8 @@ void WI_drawTime(int x,
 #if defined(MODE_T8050) || defined(MODE_T8043)
 				V_WriteTextDirect(x / 4, y / 4, ":");
 #endif
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-				V_DrawPatchScreen0(x, y, colon);
-#endif
-#if defined(USE_BACKBUFFER)
-				V_DrawPatchDirect(x, y, colon);
+#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT) || defined(USE_BACKBUFFER)
+				V_DrawPatchModeCentered(x, y, colon);
 #endif
 			}
 		} while (t / div);
@@ -825,11 +788,8 @@ void WI_drawTime(int x,
 	else
 	{
 		// "sucks"
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-		V_DrawPatchScreen0(x - sucks->width, y, sucks);
-#endif
-#if defined(USE_BACKBUFFER)
-		V_DrawPatchDirect(x - sucks->width, y, sucks);
+#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT) || defined(USE_BACKBUFFER)
+		V_DrawPatchModeCentered(x - sucks->width, y, sucks);
 #endif
 	}
 }
@@ -1138,14 +1098,11 @@ void WI_drawStats(void)
 #if defined(MODE_T8050) || defined(MODE_T8043)
 	V_WriteTextDirect(SP_STATSX / 2, SP_STATSY / 4, "KILLS:");
 #endif
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-	V_DrawPatchScreen0(SP_STATSX, SP_STATSY, kills);
-#endif
-#if defined(USE_BACKBUFFER)
-	V_DrawPatchDirect(SP_STATSX, SP_STATSY, kills);
+#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT) || defined(USE_BACKBUFFER)
+	V_DrawPatchModeCentered(SP_STATSX, SP_STATSY, kills);
 #endif
 
-	WI_drawPercent(SCREENWIDTH - SP_STATSX, SP_STATSY, cnt_kills);
+	WI_drawPercent(320 - SP_STATSX, SP_STATSY, cnt_kills);
 
 #if defined(MODE_T4025) || defined(MODE_T4050)
 	V_WriteTextDirect(SP_STATSX / 4, (SP_STATSY + lh) / 8, "ITEMS:");
@@ -1156,14 +1113,11 @@ void WI_drawStats(void)
 #if defined(MODE_T8050) || defined(MODE_T8043)
 	V_WriteTextDirect(SP_STATSX / 2, (SP_STATSY + lh) / 4, "ITEMS:");
 #endif
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-	V_DrawPatchScreen0(SP_STATSX, SP_STATSY + lh, items);
-#endif
-#if defined(USE_BACKBUFFER)
-	V_DrawPatchDirect(SP_STATSX, SP_STATSY + lh, items);
+#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT) || defined(USE_BACKBUFFER)
+	V_DrawPatchModeCentered(SP_STATSX, SP_STATSY + lh, items);
 #endif
 
-	WI_drawPercent(SCREENWIDTH - SP_STATSX, SP_STATSY + lh, cnt_items);
+	WI_drawPercent(320 - SP_STATSX, SP_STATSY + lh, cnt_items);
 
 #if defined(MODE_T4025) || defined(MODE_T4050)
 	V_WriteTextDirect(SP_STATSX / 4, (SP_STATSY + 2 * lh) / 8, "SECRET:");
@@ -1174,13 +1128,10 @@ void WI_drawStats(void)
 #if defined(MODE_T8050) || defined(MODE_T8043)
 	V_WriteTextDirect(SP_STATSX / 2, (SP_STATSY + 2 * lh) / 4, "SECRET:");
 #endif
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-	V_DrawPatchScreen0(SP_STATSX, SP_STATSY + 2 * lh, sp_secret);
+#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT) || defined(USE_BACKBUFFER)
+	V_DrawPatchModeCentered(SP_STATSX, SP_STATSY + 2 * lh, sp_secret);
 #endif
-#if defined(USE_BACKBUFFER)
-	V_DrawPatchDirect(SP_STATSX, SP_STATSY + 2 * lh, sp_secret);
-#endif
-	WI_drawPercent(SCREENWIDTH - SP_STATSX, SP_STATSY + 2 * lh, cnt_secret);
+	WI_drawPercent(320 - SP_STATSX, SP_STATSY + 2 * lh, cnt_secret);
 
 #if defined(MODE_T4025) || defined(MODE_T4050)
 	V_WriteTextDirect(SP_TIMEX / 4, SP_TIMEY / 8, "TIME:");
@@ -1191,33 +1142,26 @@ void WI_drawStats(void)
 #if defined(MODE_T8050) || defined(MODE_T8043)
 	V_WriteTextDirect(SP_TIMEX / 2, SP_TIMEY / 4, "TIME:");
 #endif
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-	V_DrawPatchScreen0(SP_TIMEX, SP_TIMEY, time);
+#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT) || defined(USE_BACKBUFFER)
+	V_DrawPatchModeCentered(SP_TIMEX, SP_TIMEY, time);
 #endif
-#if defined(USE_BACKBUFFER)
-	V_DrawPatchDirect(SP_TIMEX, SP_TIMEY, time);
-#endif
-	WI_drawTime(SCREENWIDTH / 2 - SP_TIMEX, SP_TIMEY, cnt_time);
+	WI_drawTime(160 - SP_TIMEX, SP_TIMEY, cnt_time);
 
 	if (wbs->epsd < 3)
 	{
 #if defined(MODE_T4025) || defined(MODE_T4050)
-		V_WriteTextDirect((SCREENWIDTH / 2 + SP_TIMEX) / 8, SP_TIMEY / 8, "PAR:");
+		V_WriteTextDirect((160 + SP_TIMEX) / 8, SP_TIMEY / 8, "PAR:");
 #endif
 #if defined(MODE_T8025) || defined(MODE_MDA)
-		V_WriteTextDirect((SCREENWIDTH / 2 + SP_TIMEX) / 4, SP_TIMEY / 8, "PAR:");
+		V_WriteTextDirect((160 + SP_TIMEX) / 4, SP_TIMEY / 8, "PAR:");
 #endif
 #if defined(MODE_T8050) || defined(MODE_T8043)
-		V_WriteTextDirect((SCREENWIDTH / 2 + SP_TIMEX) / 4, SP_TIMEY / 4, "PAR:");
+		V_WriteTextDirect((160 + SP_TIMEX) / 4, SP_TIMEY / 4, "PAR:");
 #endif
-#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT)
-		V_DrawPatchScreen0(SCREENWIDTH / 2 + SP_TIMEX, SP_TIMEY, par);
+#if defined(MODE_Y) || defined(MODE_VBE2_DIRECT) || defined(USE_BACKBUFFER)
+    V_DrawPatchModeCentered(160 + SP_TIMEX, SP_TIMEY, par);
 #endif
-#if defined(USE_BACKBUFFER)
-		V_DrawPatchDirect(SCREENWIDTH / 2 + SP_TIMEX, SP_TIMEY, par);
-#endif
-
-		WI_drawTime(SCREENWIDTH - SP_TIMEX, SP_TIMEY, cnt_par);
+		WI_drawTime(320 - SP_TIMEX, SP_TIMEY, cnt_par);
 	}
 }
 
@@ -1313,7 +1257,11 @@ void WI_loadData(void)
 
 	// background
 	bg = W_CacheLumpName(name, PU_CACHE);
-	V_DrawPatch(0, 0, screen1, bg);
+#if CENTERING_OFFSET_X != 0
+  // Fill screen with black
+  SetDWords(screen1, 0, SCREENWIDTH * SCREENHEIGHT / 4);
+#endif
+	V_DrawPatch(CENTERING_OFFSET_X, CENTERING_OFFSET_Y, screen1, bg);
 #endif
 
 	if (gamemode == commercial)

--- a/FASTDOOM/z_zone.c
+++ b/FASTDOOM/z_zone.c
@@ -160,8 +160,17 @@ void *Z_Malloc(int size, byte tag, void *user)
     rover = base;
     start = base->prev;
 
-    do
+    while(1)
     {
+        if (base->size >= size && !base->user) {
+          // Found a free block of sufficient size
+          break;
+        }
+        if (rover->next == start)
+        {
+            // scanned all the way around the list
+            I_Error("Z_Malloc: failed on allocation of %i bytes", size);
+        }
         if (rover->user)
         {
             if (rover->tag < PU_PURGELEVEL)
@@ -183,7 +192,7 @@ void *Z_Malloc(int size, byte tag, void *user)
         }
         else
             rover = rover->next;
-    } while (base->user || base->size < size);
+    }
 
     // found a block big enough
     extra = base->size - size;
@@ -244,8 +253,17 @@ void *Z_MallocUnowned(int size, byte tag)
     rover = base;
     start = base->prev;
 
-    do
+    while(1)
     {
+        if (base->size >= size && !base->user) {
+          // Found a free block of sufficient size
+          break;
+        }
+        if (rover->next == start)
+        {
+            // scanned all the way around the list
+            I_Error("Z_Malloc: failed on allocation of %i bytes", size);
+        }
         if (rover->user)
         {
             if (rover->tag < PU_PURGELEVEL)
@@ -267,7 +285,7 @@ void *Z_MallocUnowned(int size, byte tag)
         }
         else
             rover = rover->next;
-    } while (base->user || base->size < size);
+    };
 
     // found a block big enough
     extra = base->size - size;

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ shift 1
 
 if [ "$target" = "fdoom.exe" ]; then
   buildopts="-dMODE_Y"
-  
+
 elif [ "$target" = "fdoomcga.exe" ]; then
   buildopts="-dMODE_CGA"
 
@@ -44,6 +44,51 @@ elif [ "$target" = "fdoomvbr.exe" ]; then
 
 elif [ "$target" = "fdoomvbd.exe" ]; then
   buildopts="-dMODE_VBE2_DIRECT"
+
+elif [ "$target" = "fdm240r.exe" ]; then
+  buildopts="-dMODE_VBE2 -dSCREENWIDTH=320 -dSCREENHEIGHT=240"
+
+elif [ "$target" = "fdm384r.exe" ]; then
+  buildopts="-dMODE_VBE2 -dSCREENWIDTH=512 -dSCREENHEIGHT=384"
+
+elif [ "$target" = "fdm400r.exe" ]; then
+  buildopts="-dMODE_VBE2 -dSCREENWIDTH=640 -dSCREENHEIGHT=400"
+
+elif [ "$target" = "fdm480r.exe" ]; then
+  buildopts="-dMODE_VBE2 -dSCREENWIDTH=640 -dSCREENHEIGHT=480"
+
+elif [ "$target" = "fdm600r.exe" ]; then
+  buildopts="-dMODE_VBE2 -dSCREENWIDTH=800 -dSCREENHEIGHT=600"
+
+elif [ "$target" = "fdm768r.exe" ]; then
+  buildopts="-dMODE_VBE2 -dSCREENWIDTH=1024 -dSCREENHEIGHT=768"
+
+elif [ "$target" = "fdm1024r.exe" ]; then
+  buildopts="-dMODE_VBE2 -dSCREENWIDTH=1280 -dSCREENHEIGHT=1024"
+
+elif [ "$target" = "fdoomvbd.exe" ]; then
+  buildopts="-dMODE_VBE2_DIRECT"
+
+elif [ "$target" = "fdm240d.exe" ]; then
+  buildopts="-dMODE_VBE2_DIRECT -dSCREENWIDTH=320 -dSCREENHEIGHT=240"
+
+elif [ "$target" = "fdm384d.exe" ]; then
+  buildopts="-dMODE_VBE2_DIRECT -dSCREENWIDTH=512 -dSCREENHEIGHT=384"
+
+elif [ "$target" = "fdm400d.exe" ]; then
+  buildopts="-dMODE_VBE2_DIRECT -dSCREENWIDTH=640 -dSCREENHEIGHT=400"
+
+elif [ "$target" = "fdm480d.exe" ]; then
+  buildopts="-dMODE_VBE2_DIRECT -dSCREENWIDTH=640 -dSCREENHEIGHT=480"
+
+elif [ "$target" = "fdm600d.exe" ]; then
+  buildopts="-dMODE_VBE2_DIRECT -dSCREENWIDTH=800 -dSCREENHEIGHT=600"
+
+elif [ "$target" = "fdm768d.exe" ]; then
+  buildopts="-dMODE_VBE2_DIRECT -dSCREENWIDTH=1024 -dSCREENHEIGHT=768"
+
+elif [ "$target" = "fdm1024d.exe" ]; then
+  buildopts="-dMODE_VBE2_DIRECT -dSCREENWIDTH=1280 -dSCREENHEIGHT=1024"
 
 elif [ "$target" = "fdoompcp.exe" ]; then
   buildopts="-dMODE_PCP"

--- a/buildall.sh
+++ b/buildall.sh
@@ -1,44 +1,19 @@
 #!/bin/bash
+set -e
 
-./rm FDOOM*.EXE
-./build.sh clean
-./build.sh fdoom.exe
-./build.sh clean
-./build.sh fdoomcga.exe
-./build.sh clean
-./build.sh fdoombwc.exe
-./build.sh clean
-./build.sh fdoomhgc.exe
-./build.sh clean
-./build.sh fdoomt1.exe
-./build.sh clean
-./build.sh fdoomt12.exe
-./build.sh clean
-./build.sh fdoomt25.exe
-./build.sh clean
-./build.sh fdoomt43.exe
-./build.sh clean
-./build.sh fdoomt50.exe
-./build.sh clean
-./build.sh fdoomvbr.exe
-./build.sh clean
-./build.sh fdoomvbd.exe
-./build.sh clean
-./build.sh fdoompcp.exe
-./build.sh clean
-./build.sh fdoomcvb.exe
-./build.sh clean
-./build.sh fdoomc16.exe
-./build.sh clean
-./build.sh fdoom13h.exe
-./build.sh clean
-./build.sh fdoommda.exe
-./build.sh clean
-./build.sh fdoomega.exe
-./build.sh clean
-./build.sh fdoomcah.exe
-./build.sh clean
-./build.sh fdoom512.exe
-./build.sh clean
-./build.sh fdoom400.exe
+
+build_list=$(grep -oP '"\$target" = "\K\w*.exe(?=")' build.sh)
+
+
+build() {
+  ./build.sh clean
+  ./build.sh $1
+}
+
+rm FDOOM*.EXE FDOOM*.MAP|| true
+for target in $build_list;
+do
+  build $target
+done
+
 ./stub.sh

--- a/stub.sh
+++ b/stub.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-
+set -e
 dosbox-x -fastlaunch -nomenu -nogui -noautoexec -noconfig -c "config -set cycles=max" -c "mount J ." -c "J:" -c "SET DOS32A=J:\DOS32A" -c "SET PATH=%PATH%;J:\DOS32A\BINW" -c "stub2.bat" &>/dev/null

--- a/stub2.bat
+++ b/stub2.bat
@@ -1,4 +1,6 @@
 @echo off
 for %%f in (fdoom*.exe) do sb /R %%f
 for %%f in (fdoom*.exe) do ss %%f dos32a.d32
+for %%f in (fdm*.exe) do sb /R %%f
+for %%f in (fdm*.exe) do ss %%f dos32a.d32
 exit


### PR DESCRIPTION
Resolves #81

Paves way for #140 and mitigates #160 

### Captured Footage Demo

https://www.youtube.com/watch?v=pgIRHeQ0e_g

### New Features to Rendering

- Avoid all hard coded references to screen size in VESA relevant code, screen size can be set by defines (as long as there is a MulX for screen width). Build adds the following new VESA binaries: 320x240 512x384 640x400 640x480 800x600 1024x768 1280x1024 in both real and direct modes.
- Optional pixel scaling for patches (IE UI and Hud). Enabled by default for all new modes except 312x512
- Preserve layout of UI elements relative to standard 320x200 mode: Centered status bar, text pinned to top left and top right, minified status in bottom left, and centered intermission/start/end screens. No need to maintain list of offsets for each resolution
- Auto detect CPU renderer when not set in config

### Features added to debugging

The many ways in which rendering could write off the end of screen memory when trying to make these changes and corrupting things later in execution prompted some time spent on adding the following features:

- Stack trace output from parsed *.map file, ability to do symbol look up arbitrary pointers, useful for outputting which render functions are enabled
- Asserts, including bounds checking for rendering (only in debug mode and configurable)
- New configurable output channels besides MDA: Serial port, Bochs E9 (Supported by Dosbox-x), and text mode screen (for stack traces)
- I_Error when out of zone memory

### Build features added

- Separate options for NASM and CC (necessary for configuring stack frames and debug symbols)
- Optional GNU Makefile along side Watcom makefile, allows for much much faster parallel builds. Enabled by default in build.sh
- build.sh has additional sanity checks (IE, does wmake exist?)
- buildall.sh automatically derives list from build.sh

### Tested hardware configurations
The following hardware configurations were tested by myself:

Pentium 60 with S3 Trio, ran at 800x600
Pentium 133 with Cirrus Logic chip Running up to 1024x768, required UniVBE
Pentium 400 and ATI Rage PRO

### Benchmarks

- I spot tested before and after benchmarks on real hardware and the differences were within a margin of error, but needs more verification and datapoints. 

### Known issues
- Wipe effect setup time with (IE, with mallocs, copies, and column major order) makes the effect lag on startup on high res modes, and skews the tick rate significantly. 
- Background around intermission/end screens isn't always properly cleared to black
- On higher res modes, we run out of zone memory due to many large mallocs of screen buffers. We technically have enough memory to do, IE, the wipe effect but fragmentation causes a contiguous region to fail to materialize after a few wipe screens. Recommend -ram parameter. 
