### PR TITLE
Add uncapped FPS option and interpolate animation state between gametics 

### DIFF
--- a/FASTDOOM/Makefile.gnu
+++ b/FASTDOOM/Makefile.gnu
@@ -218,14 +218,15 @@ fdoom.exe : $(GLOBOBJS)
 DELCMD=rm -f
 
 clean:
-	$(DELCMD) *.exe
-	$(DELCMD) *.map
-	$(DELCMD) *.err
-	$(DELCMD) *.obj
-	$(DELCMD) *.sym
-	$(DELCMD) *.EXE
-	$(DELCMD) *.MAP
-	$(DELCMD) *.ERR
-	$(DELCMD) *.OBJ
-	$(DELCMD) *.SYM
+	pwd
+	-$(DELCMD) *.exe
+	-$(DELCMD) *.map
+	-$(DELCMD) *.err
+	-$(DELCMD) *.obj
+	-$(DELCMD) *.sym
+	-$(DELCMD) *.EXE
+	-$(DELCMD) *.MAP
+	-$(DELCMD) *.ERR
+	-$(DELCMD) *.OBJ
+	-$(DELCMD) *.SYM
 

--- a/FASTDOOM/d_main.c
+++ b/FASTDOOM/d_main.c
@@ -1705,6 +1705,7 @@ void D_DoomMain(void)
     M_CheckParmDisable("-melt", &noMelt);
     M_CheckParmDisable("-fastbus", &busSpeed);
     M_CheckParmDisable("-novsync", &waitVsync);
+    M_CheckParmDisable("-capped", &uncappedFPS);
     M_CheckParmDisable("-nofps", &showFPS);
 
 #if defined(MODE_T8025) || defined(MODE_T8050) || defined(MODE_T8043) || defined(MODE_T4025) || defined(MODE_T4050) || defined(MODE_MDA)

--- a/FASTDOOM/d_main.c
+++ b/FASTDOOM/d_main.c
@@ -556,7 +556,7 @@ void D_DoomLoop(void)
                // This allows us to benchmark the impact of the interpolation
                // logic on the render code
                D_SetupInterpolation();
-               interpolationweight = 0x1000;
+               interpolation_weight = 0x10000;
             }
             I_StartTic();
             D_ProcessEvents();
@@ -616,7 +616,7 @@ void D_DoomLoopBenchmark(void)
         if (uncappedFPS)
         {
             D_SetupInterpolation();
-            interpolationweight = 0x1000;
+            interpolation_weight = 0x10000;
         }
         // process one or more tics
         I_StartTic();

--- a/FASTDOOM/d_main.c
+++ b/FASTDOOM/d_main.c
@@ -608,7 +608,7 @@ void D_DoomLoopBenchmark(void)
                             // TODO rdtsc for later CPUs?
     while (1)
     {
-        start_time = mscount;
+        start_time = ticcount;
 
         if (uncappedFPS)
         {

--- a/FASTDOOM/d_main.c
+++ b/FASTDOOM/d_main.c
@@ -589,7 +589,9 @@ void D_DoomLoopBenchmark(void)
     unsigned int start_time, end_time;
 
     I_InitGraphics();
-
+    I_SetHrTimerEnabled(1); // Enable the 560Hz timer for doing frametime
+                            // recording
+                            // TODO rdtsc for later CPUs?
     while (1)
     {
         frame_ticcount = ticcount;

--- a/FASTDOOM/d_main.c
+++ b/FASTDOOM/d_main.c
@@ -110,6 +110,7 @@ boolean nearSprites;
 boolean monoSound;
 boolean noMelt;
 boolean uncappedFPS;
+boolean highResTimer;
 
 boolean reverseStereo;
 
@@ -550,7 +551,7 @@ void D_DoomLoop(void)
         // process one or more tics
         if (singletics)
         {
-            if (uncappedFPS) {
+            if (highResTimer) {
                // This allows us to benchmark the impact of the interpolation
                // logic on the render code
                D_SetupInterpolation();
@@ -592,7 +593,7 @@ void D_DoomLoop(void)
         // frame updates since they may be interpolated. However,
         // with singletics we don't invoke TryRunTics and so we
         // need to update the display here.
-        if (!uncappedFPS || singletics) {
+        if (!highResTimer || singletics) {
           D_Display();
         }
     }
@@ -610,7 +611,7 @@ void D_DoomLoopBenchmark(void)
     {
         start_time = ticcount;
 
-        if (uncappedFPS)
+        if (highResTimer)
         {
             D_SetupInterpolation();
             interpolation_weight = 0x10000;

--- a/FASTDOOM/d_main.h
+++ b/FASTDOOM/d_main.h
@@ -55,7 +55,9 @@ void D_PageDrawer(void);
 void D_AdvanceDemo(void);
 void D_StartTitle(void);
 
-void D_Display(void);
+// Returns whether a frame was drawn in the case that interpolation is enabled
+// (uncappedFPS) and we would overshoot the target time.
+int D_Display(void);
 
 #if defined(MODE_CGA512)
 enum CGA_MODEL

--- a/FASTDOOM/d_main.h
+++ b/FASTDOOM/d_main.h
@@ -55,9 +55,7 @@ void D_PageDrawer(void);
 void D_AdvanceDemo(void);
 void D_StartTitle(void);
 
-// Returns whether a frame was drawn in the case that interpolation is enabled
-// (uncappedFPS) and we would overshoot the target time.
-int D_Display(void);
+void D_Display(void);
 
 #if defined(MODE_CGA512)
 enum CGA_MODEL
@@ -67,7 +65,7 @@ enum CGA_MODEL
 };
 #endif
 
-// Called by TryRunTics when uncappedFPS is set to copy animation state
+// Called before G_Ticker when uncappedFPS is set to copy animation state
 // so that we can interpolate between tics
 void D_SetupInterpolation(void);
 #endif

--- a/FASTDOOM/d_main.h
+++ b/FASTDOOM/d_main.h
@@ -65,4 +65,7 @@ enum CGA_MODEL
 };
 #endif
 
+// Called by TryRunTics when uncappedFPS is set to copy animation state
+// so that we can interpolate between tics
+void D_SetupInterpolation(void);
 #endif

--- a/FASTDOOM/d_net.c
+++ b/FASTDOOM/d_net.c
@@ -146,8 +146,17 @@ void TryRunTics(void)
 			M_Ticker();
 			return;
 		}
-		if (uncappedFPS) {
-			D_Display();
+		if (uncappedFPS)
+		{
+			if (!D_Display()) {
+				// We don't have time to draw the interpolated, so we need to skip
+				// straight to the next tic.
+				// Note that D_Display in interpolation mode is doing timing
+				// measurements so even though we are fast forwarding here,
+				// everyhting will be in sync.
+				maketic = gametic + counts;
+				break;
+			}
 		}
 	}
 	// run the count dics

--- a/FASTDOOM/d_net.c
+++ b/FASTDOOM/d_net.c
@@ -286,7 +286,7 @@ void TryRunTicsUncapped(void)
 
 void TryRunTics(void)
 {
-	if (uncappedFPS && !singletics) {
+	if (highResTimer && !singletics) {
 		TryRunTicsUncapped();
 	} else {
 		TryRunTicsCapped();

--- a/FASTDOOM/d_net.c
+++ b/FASTDOOM/d_net.c
@@ -146,8 +146,14 @@ void TryRunTics(void)
 			M_Ticker();
 			return;
 		}
+		if (uncappedFPS) {
+			D_Display();
+		}
 	}
-
+	if (uncappedFPS) {
+		// Copy the current frame state before we update the game state
+		D_SetupInterpolation();
+	}
 	// run the count dics
 	while (counts--)
 	{

--- a/FASTDOOM/d_net.c
+++ b/FASTDOOM/d_net.c
@@ -150,10 +150,6 @@ void TryRunTics(void)
 			D_Display();
 		}
 	}
-	if (uncappedFPS) {
-		// Copy the current frame state before we update the game state
-		D_SetupInterpolation();
-	}
 	// run the count dics
 	while (counts--)
 	{

--- a/FASTDOOM/d_net.c
+++ b/FASTDOOM/d_net.c
@@ -9,17 +9,19 @@
 //
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
 // GNU General Public License for more details.
 //
 // DESCRIPTION:
-//  DOOM Network game communication and protocol,
-//  all OS independend parts.
+//	DOOM Network game communication and protocol,
+//	all OS independend parts.
 //
 
 #include "m_menu.h"
 #include "i_system.h"
 #include "g_game.h"
+#include "r_main.h"
+#include "i_debug.h"
 #include "doomdef.h"
 #include "doomstat.h"
 #include "d_main.h"
@@ -99,13 +101,43 @@ void D_CheckNetGame(void)
 	maketic = 0;
 }
 
+
+extern byte advancedemo;
+
+void RunTick(void)
+{
+		if (advancedemo)
+			D_DoAdvanceDemo();
+		M_Ticker();
+		G_Ticker();
+		gametic++;
+		NetUpdate(); // check for new console commands
+}
+
+void RunTickUncapped(void)
+{
+		// TODO (dougvj) I am not sure how to handle the events here, it seems like
+		// doing it asynchronously like the TryRunTics causes buffering issues
+		// May just have to tell people to not use uncapped mode for low
+		// performance systems
+		I_StartTic();
+		D_ProcessEvents();
+		G_BuildTiccmd(&localcmds[maketic & (BACKUPTICS-1)]);
+		if (advancedemo)
+			D_DoAdvanceDemo();
+		M_Ticker();
+		D_SetupInterpolation();
+		G_Ticker();
+		gametic++;
+		maketic = gametic + 1;
+}
+
 //
 // TryRunTics
 //
 
-extern byte advancedemo;
 
-void TryRunTics(void)
+void TryRunTicsCapped(void)
 {
 	int i;
 	int entertic;
@@ -136,7 +168,7 @@ void TryRunTics(void)
 		counts = 1;
 
 	// wait for new tics if needed
-	while (maketic < gametic + counts)
+	while (maketic < gametic + counts || uncappedFPS)
 	{
 		NetUpdate();
 
@@ -146,27 +178,116 @@ void TryRunTics(void)
 			M_Ticker();
 			return;
 		}
-		if (uncappedFPS)
-		{
-			if (!D_Display()) {
-				// We don't have time to draw the interpolated, so we need to skip
-				// straight to the next tic.
-				// Note that D_Display in interpolation mode is doing timing
-				// measurements so even though we are fast forwarding here,
-				// everyhting will be in sync.
-				maketic = gametic + counts;
-				break;
-			}
-		}
 	}
 	// run the count dics
 	while (counts--)
 	{
-		if (advancedemo)
-			D_DoAdvanceDemo();
-		M_Ticker();
-		G_Ticker();
-		gametic++;
-		NetUpdate(); // check for new console commands
+		RunTick();
+	}
+}
+
+// Returns the number of tics that ran. Renders interpolated frames between
+// ticks if our rendering is fast enough
+int ProcessInterpolationAndTics(void) {
+	int ticks_ran = 0;
+	// First get the time between the last run and the current run
+	static int last_ts = 0;
+	static int frametime = 0;
+	unsigned int new_ts = ticcount_hr;
+	// See how many gametics should have elapsed (quantized to 16) ticks,
+	// since our hr timer is 1/560 and /16 is 1/35
+	int gametics_elapsed = (new_ts >> 4) - (last_ts >> 4);
+	int time_elapsed_since_last_process = new_ts - last_ts;
+	//I_Printf("last_ts: %d\n", last_ts);
+	//I_Printf("new_ts: %d\n", new_ts);
+	//I_Printf("time_elapsed_since_last_process: %d\n", time_elapsed_since_last_process);
+	if (time_elapsed_since_last_process <= 0) {
+		// Don't bother calculating anything new just rerender the
+		// previous frame. If we are hitting this then we are > 560 fps
+		goto render_frame;
+	}
+	last_ts = new_ts;
+	// If any gametics have elapsed since our last run let's process them.
+	if (gametics_elapsed > 0) {
+		ticks_ran = gametics_elapsed;
+		while (gametics_elapsed--) {
+			RunTickUncapped();
+		}
+	}
+	if (frametime > 16) {
+		// We are too slow to really interpolate frames
+		if (interpolationweight != 0x10000) {
+			// We need to reset the interpolation weight
+			// to 0x10000 (1.0) but let's not do it immediately
+			// becasue that creates a visual artifact
+			// We should tell people that if they are near 35 fps in performance,
+			// they should just run in vsync or capped mode
+			interpolationweight += 0x1000;
+			if (interpolationweight >= 0x10000) {
+				interpolationweight = 0x10000;
+			}
+		}
+		goto render_frame;
+	} else {
+		// Now let's process the interpolation weight
+		// First figure out where we are in the current gametic
+		// We take the lower 4 bits at 0 as the idealized gametic
+		// dispatch, so that the lower 4 bits correspond to between
+		// gametics
+		int current_time_in_gametic = new_ts & 0xf;
+		// Where will we be in the next frame Use our last frametime
+		// to guesstimate
+		int next_time_in_gametic = current_time_in_gametic + frametime;
+		// If we are going to be in the next gametic, then we will have to
+		// run the next gametic to do the next interpolation
+		if (next_time_in_gametic > 16) {
+			ticks_ran += 1;
+			RunTickUncapped();
+			// Adjust the last_ts to the beggining of the next
+			// gametic so that we account for running this one early
+			// when calculating gametics_elapsed
+			last_ts += 16 - current_time_in_gametic;
+			// Now move the next_time_in_gametic back to the current gametic
+			// since it's been processed
+			next_time_in_gametic -= 16;
+		}
+		// OK we are safely in the current gametic, convert our time to a
+		// fixed point number used by the interpolation routine
+		interpolationweight = (next_time_in_gametic) << 12;
+		ASSERT(interpolationweight <= 0x10000 && interpolationweight >= 0);
+	}
+render_frame:
+	{
+		// Render the frame, recording the frametime for the
+		// interpolation of the next frame
+		int last_framets = ticcount_hr;
+		int new_framets;
+		D_Display();
+		new_framets = ticcount_hr;
+		frametime = new_framets - last_framets;
+	}
+	return ticks_ran;
+}
+
+// Like the above but we use an HR timer and D_Display to manage the frame
+// and tic rate
+void TryRunTicsUncapped(void)
+{
+	int counts;
+	while(1) {
+		counts = ProcessInterpolationAndTics();
+		if (counts > 0) {
+			// IF we ran any tics, we need to break to handle sound etc
+			break;
+		}
+	}
+}
+
+void TryRunTics(void)
+{
+	if (uncappedFPS && !singletics) {
+		TryRunTicsUncapped();
+	} else {
+		TryRunTicsCapped();
 	}
 }

--- a/FASTDOOM/d_player.h
+++ b/FASTDOOM/d_player.h
@@ -71,6 +71,7 @@ typedef struct player_s
     //  including viewpoint bobbing during movement.
     // Focal origin above r.z
     fixed_t viewz;
+    fixed_t prevviewz; // Used for interpolation
     // Base height above floor for viewz.
     fixed_t viewheight;
     // Bob/squat speed.

--- a/FASTDOOM/dbgcfg.h
+++ b/FASTDOOM/dbgcfg.h
@@ -34,4 +34,4 @@
 // will be outputted to the other enabled debug outputs.
 #define DEBUG_SHOW_BACKTRACE_ON_SCREEN 0
 // Whether to quit the game when a backtrace is requested.
-#define DEBUG_DIE_ON_BACKTRACE 0
+#define DEBUG_DIE_ON_BACKTRACE 1

--- a/FASTDOOM/dbgcfg.h
+++ b/FASTDOOM/dbgcfg.h
@@ -1,6 +1,6 @@
 // Comment this out to indicate debugging is configured!
 // Uncomment after reviewing the options. TODO - .gitignore?
-#define DEBUG_UNCONFIGURED
+ #define DEBUG_UNCONFIGURED
 
 // Enables bounds checking for screen coordinates.
 // This will die and show a backtrace if the coordinates are out of bounds.

--- a/FASTDOOM/dbgcfg.h
+++ b/FASTDOOM/dbgcfg.h
@@ -1,15 +1,37 @@
-// #define DEBUG_MDA_ENABLED 1
+// Comment this out to indicate debugging is configured!
+// Uncomment after reviewing the options. TODO - .gitignore?
+#define DEBUG_UNCONFIGURED
 
-// #define BOCHS_DEBUG_ENABLED 1
+// Enables bounds checking for screen coordinates.
+// This will die and show a backtrace if the coordinates are out of bounds.
+#define BOUNDS_CHECK_ENABLED 1
 
-// #define DEBUG_FILE_ENABLED 1
+// Asserts enabled
+#define ASSERT_ENABLED 1
 
-// #define DEBUG_SERIAL_ENABLED 1
-// #define DEBUG_SERIAL_BASE_IO 0x3F8
-// #define DEBUG_SERIAL_BAUD 38400
+// Enables output to the bochs debug port displaed by dosbox-x and bochs
+// when running on emulators. Disabled by default.
+// Set the option 'bochs debug port e9 = true' in dosbox.conf to enable
+// This doesn't correspond to any real hardware but it could, so we disable
+// it by default.
+#define BOCHS_DEBUG_ENABLED 1
 
-// #define BOUNDS_CHECK_ENABLED 1
-// #define ASSERT_ENABLED 1
+// Enables the MDA debug output for a real or emulated MDA card
+#define DEBUG_MDA_ENABLED 0
 
-// #define DEBUG_DIE_ON_BACKTRACE 1
-// #define DEBUG_SHOW_BACKTRACE_ON_SCREEN 1
+// Enables the serial debug output and sets the parameters
+// These are the default values for serial port 1
+#define DEBUG_SERIAL_ENABLED 0
+#define DEBUG_SERIAL_BASE_IO 0x3f8
+#define DEBUG_SERIAL_BAUD 115200
+
+// Whether to shutdown graphics and print the backtrace to the screen
+// when a backtrace is requested. Otherwise, it will only be outputted to
+// the other enabled debug outputs. This will also pause the game if
+// DEBUG_DIE_ON_BACKTRACE is set to 0.
+//
+// When set to 0, the game will not show a backtraces on the screen, but they
+// will be outputted to the other enabled debug outputs.
+#define DEBUG_SHOW_BACKTRACE_ON_SCREEN 0
+// Whether to quit the game when a backtrace is requested.
+#define DEBUG_DIE_ON_BACKTRACE 0

--- a/FASTDOOM/doomstat.h
+++ b/FASTDOOM/doomstat.h
@@ -227,7 +227,6 @@ extern gamestate_t gamestate;
 //  WAD, partly set at startup time.
 
 extern int gametic;
-extern unsigned int gameticstart;
 
 // Bookkeeping on players - state.
 extern player_t players;

--- a/FASTDOOM/doomstat.h
+++ b/FASTDOOM/doomstat.h
@@ -99,6 +99,7 @@ extern boolean disableDemo;
 extern boolean busSpeed;
 extern boolean waitVsync;
 extern boolean uncappedFPS;
+extern boolean highResTimer;
 
 // Set if homebrew PWAD stuff has been added.
 extern boolean modifiedgame;

--- a/FASTDOOM/doomstat.h
+++ b/FASTDOOM/doomstat.h
@@ -98,6 +98,7 @@ extern boolean disableDemo;
 
 extern boolean busSpeed;
 extern boolean waitVsync;
+extern boolean uncappedFPS;
 
 // Set if homebrew PWAD stuff has been added.
 extern boolean modifiedgame;
@@ -226,6 +227,7 @@ extern gamestate_t gamestate;
 //  WAD, partly set at startup time.
 
 extern int gametic;
+extern unsigned int gameticstart;
 
 // Bookkeeping on players - state.
 extern player_t players;

--- a/FASTDOOM/fastmath.h
+++ b/FASTDOOM/fastmath.h
@@ -27,16 +27,22 @@ typedef int fixed_t;
 
 #define FRACBITS 16
 #define FRACUNIT (1 << FRACBITS)
-  
+
 #define PI_F 3.14159265f
 #define FIXED_TO_FLOAT(inp)       ((float)inp) / (1 << FRACBITS)
 #define FLOAT_TO_FIXED(inp)       (fixed_t)(inp * (1 << FRACBITS))
 #define ANGLE_TO_FLOAT(x)       (x * ((float)(PI_F / 4096.0f)))
 
+
 fixed_t FixedMul(fixed_t a, fixed_t b);
 #pragma aux FixedMul = \
     "imul ebx",        \
     "shrd eax,edx,16" parm[eax][ebx] value[eax] modify exact[eax edx]
+
+inline fixed_t FixedInterpolate(fixed_t a, fixed_t b, fixed_t frac)
+{
+    return a + FixedMul(b - a, frac);
+}
 
 fixed_t FixedMulECX(fixed_t a, fixed_t b);
 #pragma aux FixedMulECX = \

--- a/FASTDOOM/fastmath.h
+++ b/FASTDOOM/fastmath.h
@@ -365,6 +365,10 @@ int Div84(int value);
     "shr ecx, 31", \
     "add edx, ecx" parm[ecx] value[edx] modify exact[eax ecx edx]
 
+int Div128(int value);
+#pragma aux Div128 = \
+    "shr eax, 7" parm[eax] value[eax] modify exact[eax]
+
 void CopyBytes(void *src, void *dest, int num_bytes);
 #pragma aux CopyBytes = \
     "rep movsb" \

--- a/FASTDOOM/g_game.c
+++ b/FASTDOOM/g_game.c
@@ -68,6 +68,10 @@
 #include "i_file.h"
 #include "i_debug.h"
 
+#include "i_log.h"
+#include "i_debug.h"
+
+#define SAVEGAMESIZE 0x2c000
 #define SAVESTRINGSIZE 24
 #define DEMOMARKER 0x80
 
@@ -107,8 +111,6 @@ player_t players;
 mobj_t *players_mo;
 
 int gametic;
-unsigned int gameticstart; // Timer counter for start of gametic, used for
-                            // frame interpolation
 int totalkills, totalitems, totalsecret; // for intermission
 
 char demoname[32];
@@ -448,13 +450,6 @@ void G_Ticker(void)
     int i;
     int buf;
     ticcmd_t *cmd;
-
-    if (uncappedFPS) {
-      // Setup the interpolation state
-      // At the beginng of every game tic
-      D_SetupInterpolation();
-      gameticstart+=16; //35 fps interval
-    }
 
     // do player reborns if needed
     if (players.playerstate == PST_REBORN)
@@ -888,9 +883,9 @@ void G_SaveGame(int slot,
 int G_CalculateSaveGameSize(void)
 {
     thinker_t *th;
-    int i;    
+    int i;
     int savesize = 0;
-    
+
     // G_DoSaveGame
     savesize += SAVESTRINGSIZE;
     savesize += VERSIONSIZE;
@@ -903,7 +898,7 @@ int G_CalculateSaveGameSize(void)
     // P_ArchiveWorld
     savesize += numsectors * 14;
     savesize += numlines * (6 + (2 * 10));
-    
+
     // P_ArchiveThinkers
     for (th = thinkercap.next; th != &thinkercap; th = th->next)
     {
@@ -915,7 +910,7 @@ int G_CalculateSaveGameSize(void)
 		}
     }
     savesize += 1;
-    
+
     // P_ArchiveSpecials
     for (th = thinkercap.next; th != &thinkercap; th = th->next)
 	{

--- a/FASTDOOM/g_game.c
+++ b/FASTDOOM/g_game.c
@@ -490,6 +490,15 @@ void G_Ticker(void)
         case ga_nothing:
             break;
         }
+
+        if (uncappedFPS)
+        {
+            highResTimer = gamestate == GS_LEVEL;
+        } else {
+            highResTimer = false;
+        }
+
+        I_SetHrTimerEnabled(highResTimer);  
     }
 
     // get commands, check consistancy,

--- a/FASTDOOM/g_game.c
+++ b/FASTDOOM/g_game.c
@@ -68,7 +68,6 @@
 #include "i_file.h"
 #include "i_debug.h"
 
-#include "i_log.h"
 #include "i_debug.h"
 
 #define SAVEGAMESIZE 0x2c000

--- a/FASTDOOM/g_game.c
+++ b/FASTDOOM/g_game.c
@@ -451,7 +451,9 @@ void G_Ticker(void)
 
     if (uncappedFPS) {
       // Setup the interpolation state
+      // At the beginng of every game tic
       D_SetupInterpolation();
+      gameticstart+=16; //35 fps interval
     }
 
     // do player reborns if needed

--- a/FASTDOOM/g_game.c
+++ b/FASTDOOM/g_game.c
@@ -334,6 +334,10 @@ extern gamestate_t wipegamestate;
 
 void G_DoLoadLevel(void)
 {
+    // Reset interpolation state to values that will force no interpolation
+    // on the first tick
+    interpolation_weight = 0x10000;
+    frametime_hrticks = 17;
     // DOOM determines the sky texture to be used
     // depending on the current episode, and the game version.
     if (gamemode == commercial)

--- a/FASTDOOM/g_game.c
+++ b/FASTDOOM/g_game.c
@@ -449,6 +449,11 @@ void G_Ticker(void)
     int buf;
     ticcmd_t *cmd;
 
+    if (uncappedFPS) {
+      // Setup the interpolation state
+      D_SetupInterpolation();
+    }
+
     // do player reborns if needed
     if (players.playerstate == PST_REBORN)
         G_DoReborn(0);

--- a/FASTDOOM/g_game.c
+++ b/FASTDOOM/g_game.c
@@ -107,6 +107,8 @@ player_t players;
 mobj_t *players_mo;
 
 int gametic;
+unsigned int gameticstart; // Timer counter for start of gametic, used for
+                            // frame interpolation
 int totalkills, totalitems, totalsecret; // for intermission
 
 char demoname[32];
@@ -1321,7 +1323,7 @@ unsigned int G_GetDemoTicks(char *demofile)
     unsigned int count;
 
     demobuffer = demo_p = W_CacheLumpName(demofile, PU_STATIC);
-    
+
     // G_DoPlayDemo
     *demo_p++;
     *demo_p++;
@@ -1598,7 +1600,7 @@ void G_SaveCSVResult(unsigned int gametics, unsigned int realtics, unsigned int 
 
         // 1% low FPS
         fprintf(logFile, "%u" CSV_DECIMAL "%.3u" CSV_COLUMN, onepercentlow / 1000, onepercentlow % 1000);
-        
+
         // 0.1% low FPS
         fprintf(logFile, "%u" CSV_DECIMAL "%.3u\n", dotonepercentlow / 1000, dotonepercentlow % 1000);
 
@@ -1736,7 +1738,7 @@ void G_CheckDemoStatus(void)
 
                 // Cleanup frametimes
                 frametime_position = 0;
-                
+
                 for (i = 0; i < benchmark_total_tics; i++)
                 {
                     frametime[i] = 0;

--- a/FASTDOOM/i_ibm.c
+++ b/FASTDOOM/i_ibm.c
@@ -248,8 +248,8 @@ extern int usemouse;
 
 byte mousepresent;
 
+unsigned int ticcount_hr;
 unsigned int ticcount;
-unsigned int mscount;
 unsigned int fps;
 
 // REGS stuff used for int calls
@@ -863,12 +863,10 @@ void I_StartTic(void)
 //
 void I_TimerISR(task *task)
 {
-    ticcount++;
-}
-
-void I_TimerMS(task *task)
-{
-    mscount++;
+    // 560 HZ
+    ticcount_hr++;
+    // 35 HZ
+    ticcount = ticcount_hr >> 4;
 }
 
 //

--- a/FASTDOOM/i_ibm.c
+++ b/FASTDOOM/i_ibm.c
@@ -891,7 +891,15 @@ void I_ShutdownTimer(void)
   TS_Shutdown();
 }
 
+int currentTimer = -1;
+
 void I_SetHrTimerEnabled(int enabled) {
+
+  if (currentTimer == enabled)
+    return;
+
+  currentTimer = enabled;
+
   if (tsm_task) {
       TS_Terminate(tsm_task);
   }
@@ -904,10 +912,11 @@ void I_SetHrTimerEnabled(int enabled) {
     tsm_task = TS_ScheduleTask(I_TimerISR, 35, 1, NULL);
   }
   TS_Dispatch();
+  
 }
 
 void I_StartupTimer(void) {
-  I_SetHrTimerEnabled(uncappedFPS);
+  I_SetHrTimerEnabled(false);
 }
 
 

--- a/FASTDOOM/i_ibm.h
+++ b/FASTDOOM/i_ibm.h
@@ -3,8 +3,9 @@
 #include "doomtype.h"
 #include "options.h"
 
+extern unsigned int ticcount_hr;
+extern unsigned int frame_ticcount;
 extern unsigned int ticcount;
-extern unsigned int mscount;
 extern unsigned int fps;
 
 extern unsigned short *currentscreen;

--- a/FASTDOOM/i_ibm.h
+++ b/FASTDOOM/i_ibm.h
@@ -24,4 +24,7 @@ extern void I_TimerISR(task *task);
 extern void I_TimerMS(task *task);
 extern void *I_DosMemAlloc(unsigned long size);
 
-extern unsigned int frame_ticcount;
+void I_StartupTimer(void);
+void I_ShutdownTimer(void);
+void I_SetHrTimerEnabled(boolean enabled);
+

--- a/FASTDOOM/i_sound.c
+++ b/FASTDOOM/i_sound.c
@@ -41,34 +41,6 @@
 
 #include "ns_cd.h"
 
-//
-// I_StartupTimer
-//
-
-task *tsm_task;
-task *tsm_ms_task;
-
-void I_StartupTimer(void)
-{
-    printf("I_StartupTimer()\n");
-    // installs master timer.  Must be done before StartupTimer()!
-    // We have a high resolution timer in order to have frame interpolation
-    // for > 35 fps. Note that the game tics are fixed to 35, which is
-    // 1/16th of the 560Hz timer.
-    tsm_task = TS_ScheduleTask(I_TimerISR, 560, 1, NULL);
-    TS_Dispatch();
-
-}
-
-void I_ShutdownTimer(void)
-{
-    if (tsm_task)
-    {
-        TS_Terminate(tsm_task);
-    }
-    tsm_task = NULL;
-    TS_Shutdown();
-}
 
 //
 // Sound header & data
@@ -278,10 +250,6 @@ void I_sndArbitrateCards(void)
 //
 void I_StartupSound(void)
 {
-    //
-    // inits sound library timer stuff
-    //
-    I_StartupTimer();
 
     //
     // pick the sound cards i'm going to use

--- a/FASTDOOM/i_sound.c
+++ b/FASTDOOM/i_sound.c
@@ -52,14 +52,12 @@ void I_StartupTimer(void)
 {
     printf("I_StartupTimer()\n");
     // installs master timer.  Must be done before StartupTimer()!
-    tsm_task = TS_ScheduleTask(I_TimerISR, 35, 1, NULL);
+    // We have a high resolution timer in order to have frame interpolation
+    // for > 35 fps. Note that the game tics are fixed to 35, which is
+    // 1/16th of the 560Hz timer.
+    tsm_task = TS_ScheduleTask(I_TimerISR, 560, 1, NULL);
     TS_Dispatch();
-    
-    if (benchmark_advanced)
-    {
-        tsm_ms_task = TS_ScheduleTask(I_TimerMS, 1000, 1, NULL);
-        TS_Dispatch();
-    }
+
 }
 
 void I_ShutdownTimer(void)

--- a/FASTDOOM/m_bench.c
+++ b/FASTDOOM/m_bench.c
@@ -55,7 +55,6 @@
 
 #include "options.h"
 
-#include "i_log.h"
 #include "i_ibm.h"
 
 #if defined(MODE_13H)

--- a/FASTDOOM/m_bench.c
+++ b/FASTDOOM/m_bench.c
@@ -55,6 +55,9 @@
 
 #include "options.h"
 
+#include "i_log.h"
+#include "i_ibm.h"
+
 #if defined(MODE_13H)
 #include "i_vga13h.h"
 #endif

--- a/FASTDOOM/m_bench.c
+++ b/FASTDOOM/m_bench.c
@@ -152,6 +152,12 @@ void M_SetBusSpeed(boolean value)
 #endif
 }
 
+void M_SetUncapped(boolean value)
+{
+    uncappedFPS = value;
+    I_SetHrTimerEnabled(uncappedFPS);
+}
+
 void M_SetSizeDisplay(int value)
 {
     screenSize = value;

--- a/FASTDOOM/m_menu.c
+++ b/FASTDOOM/m_menu.c
@@ -2160,10 +2160,12 @@ void M_ChangeBusSpeed(int choice)
     players.message = busSpeed ? "SLOW BUS" : "FAST BUS";
 }
 
+void I_SetHrTimerEnabled(int enabled);
+
 void M_ChangeUncappedFPS(int choice)
 {
     uncappedFPS = !uncappedFPS;
-
+    I_SetHrTimerEnabled(uncappedFPS);
     players.message = uncappedFPS ? "UNCAPPED FPS" : "CAPPED FPS";
 }
 

--- a/FASTDOOM/m_menu.c
+++ b/FASTDOOM/m_menu.c
@@ -2165,7 +2165,16 @@ void I_SetHrTimerEnabled(int enabled);
 void M_ChangeUncappedFPS(int choice)
 {
     uncappedFPS = !uncappedFPS;
-    I_SetHrTimerEnabled(uncappedFPS);
+
+    if (uncappedFPS) 
+    {
+        highResTimer = gamestate == GS_LEVEL;
+    } else {
+        highResTimer = false;
+    }
+
+    I_SetHrTimerEnabled(highResTimer);
+
     players.message = uncappedFPS ? "UNCAPPED FPS" : "CAPPED FPS";
 }
 

--- a/FASTDOOM/m_menu.c
+++ b/FASTDOOM/m_menu.c
@@ -210,6 +210,7 @@ void M_ChangeShowFPS(int choice);
 void M_ChangeSpriteCulling(int choice);
 void M_ChangeMelting(int choice);
 void M_ChangeBusSpeed(int choice);
+void M_ChangeUncappedFPS(int choice);
 void M_ChangeMono();
 void M_SizeDisplay(int choice);
 void M_Sound(int choice);
@@ -346,7 +347,8 @@ menu_t NewDef =
 #define melting 10
 #define bus_speed 11
 #define cpu 12
-#define display_end 13
+#define uncapped_fps 13
+#define display_end 14
 
 #define endgame 0
 #define messages 1
@@ -394,7 +396,8 @@ menuitem_t DisplayMenu[] =
         {2, "", "", M_ChangeSpriteCulling},
         {2, "", "", M_ChangeMelting},
         {2, "", "", M_ChangeBusSpeed},
-        {2, "", "", M_ChangeCPU}};
+        {2, "", "", M_ChangeCPU},
+        {2, "", "", M_ChangeUncappedFPS}};
 
 menu_t DisplayDef =
     {
@@ -1481,6 +1484,10 @@ void M_DrawDisplayItem(int item, int position)
             break;
         }
         break;
+    case uncapped_fps:
+        M_WriteText(58, y, "UNCAPPED FPS:");
+        M_WriteText(214, y, uncappedFPS ? "ON" : "OFF");
+        break;
     }
 }
 #endif
@@ -1637,6 +1644,10 @@ void M_DrawDisplayItem(int item, int position)
             V_WriteTextDirect(M_X2, y, "INTEL PENTIUM");
             break;
         }
+        break;
+    case uncapped_fps:
+        V_WriteTextDirect(M_X1, y, "UNCAPPED FPS:");
+        V_WriteTextDirect(M_X1, y, uncappedFPS ? "ON" : "OFF");
         break;
     }
 }
@@ -2147,6 +2158,13 @@ void M_ChangeBusSpeed(int choice)
 #endif
 
     players.message = busSpeed ? "SLOW BUS" : "FAST BUS";
+}
+
+void M_ChangeUncappedFPS(int choice)
+{
+    uncappedFPS = !uncappedFPS;
+
+    players.message = uncappedFPS ? "UNCAPPED FPS" : "CAPPED FPS";
 }
 
 void M_ChangeMono()

--- a/FASTDOOM/m_misc.c
+++ b/FASTDOOM/m_misc.c
@@ -82,9 +82,9 @@ int M_CheckParmOptional(char *check, int *variable)
         if (!strcasecmp(check, myargv[i])){
             *variable = i;
             return 1;
-        }            
+        }
     }
-    
+
     return 0;
 }
 
@@ -97,9 +97,9 @@ int M_CheckParmOptionalValue(char *check, int *variable, int value)
         if (!strcasecmp(check, myargv[i])){
             *variable = value;
             return 1;
-        }            
+        }
     }
-    
+
     return 0;
 }
 
@@ -113,7 +113,7 @@ int M_CheckParmDisable(char *check, int *variable)
             *variable = 0;
             return 1;
         }
-            
+
     }
 
     return 0;
@@ -129,7 +129,7 @@ void M_AddToBox(fixed_t *box, fixed_t x, fixed_t y)
 
     if (box[BOXBOTTOM] > y)
         box[BOXBOTTOM] = y;
-    else 
+    else
         if (box[BOXTOP] < y)
             box[BOXTOP] = y;
 }
@@ -310,6 +310,7 @@ default_t defaults[] =
         {"debugCardPort", &debugCardPort, 0x80},
         {"debugCardReverse", &debugCardReverse, 0},
         {"busSpeed", &busSpeed, 0},
+        {"uncapped", &uncappedFPS, 0},
         {"flatsky", &flatSky, 0},
         {"near", &nearSprites, 0},
         {"nomelt", &noMelt, 0},

--- a/FASTDOOM/p_enemy.c
+++ b/FASTDOOM/p_enemy.c
@@ -220,7 +220,7 @@ byte P_NotMove(mobj_t *actor)
 
     // warning: 'catch', 'throw', and 'try'
     // are all C++ reserved words
-    
+
     fixed_t optSpeed;
 
     switch (actor->movedir)
@@ -644,7 +644,7 @@ void A_Chase(mobj_t *actor)
     if (actor->movedir < 8)
     {
         int delta;
-        
+
         actor->angle &= (7 << 29);
         delta = actor->angle - (((int)actor->movedir) << 29);
 
@@ -733,7 +733,7 @@ void A_FaceTarget(mobj_t *actor)
         actor->angle += (P_Random_Minus_P_Random) << 21;
         prndindex += 2;
     }
-        
+
 }
 
 //

--- a/FASTDOOM/p_floor.c
+++ b/FASTDOOM/p_floor.c
@@ -21,7 +21,7 @@
 #include "z_zone.h"
 #include "doomdef.h"
 #include "p_local.h"
-
+#include "i_debug.h"
 #include "s_sound.h"
 
 // State.

--- a/FASTDOOM/p_map.c
+++ b/FASTDOOM/p_map.c
@@ -524,7 +524,6 @@ byte P_TryMove(mobj_t *thing, fixed_t x, fixed_t y)
     thing->ceilingz = tmceilingz;
     thing->x = x;
     thing->y = y;
-
     P_SetThingPositionSubsector(thing, newsubsec);
 
     // if any special lines were hit, do the effect

--- a/FASTDOOM/p_mobj.c
+++ b/FASTDOOM/p_mobj.c
@@ -357,7 +357,7 @@ void P_NightmareRespawn(mobj_t *mobj)
 
     // VITI95: OPTIMIZE
     mo->angle = ANG45 * (mthing->angle / 45);
-
+    mo->prevangle = mo->angle;
     if (mthing->options & MTF_AMBUSH)
         mo->flags |= MF_AMBUSH;
 
@@ -457,6 +457,8 @@ P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, byte type)
     mobj->info = info;
     mobj->x = x;
     mobj->y = y;
+    mobj->prevx = x;
+    mobj->prevy = y;
     mobj->radius = info->radius;
     mobj->height = info->height;
     mobj->flags = info->flags;
@@ -488,7 +490,7 @@ P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, byte type)
         mobj->z = mobj->ceilingz - mobj->info->height;
     else
         mobj->z = z;
-
+    mobj->prevz = mobj->z;
     if (mobj->type < MT_MISC0)
     {
         mobj->thinker.function.acp1 = (actionf_p1)P_MobjThinker;
@@ -571,6 +573,7 @@ void P_SpawnPlayer(mapthing_t *mthing)
 
     // VITI95: OPTIMIZE
     mobj->angle = ANG45 * (mthing->angle / 45);
+    mobj->prevangle = mobj->angle;
     mobj->player = p;
     mobj->health = p->health;
 
@@ -666,9 +669,10 @@ void P_SpawnMapThing(mapthing_t *mthing)
 
     totalkills += (mobj->flags & MF_COUNTKILL) != 0;
     totalitems += (mobj->flags & MF_COUNTITEM) != 0;
-    
+
     // VITI95: OPTIMIZE
     mobj->angle = ANG45 * (mthing->angle / 45);
+    mobj->prevangle = mobj->angle;
     if (mthing->options & MTF_AMBUSH)
         mobj->flags |= MF_AMBUSH;
 }
@@ -847,6 +851,7 @@ void P_SpawnPlayerMissile(byte type)
 
     th->target = players_mo;
     th->angle = an;
+    th->prevangle = an;
 
     an >>= ANGLETOFINESHIFT;
 

--- a/FASTDOOM/p_mobj.h
+++ b/FASTDOOM/p_mobj.h
@@ -210,6 +210,13 @@ typedef struct mobj_s
     byte sprite; // used to find patch_t and flip value
     int frame;          // might be ORed with FF_FULLBRIGHT
 
+    // The following is used for interpolation frames.
+    fixed_t prevx;
+    fixed_t prevy;
+    fixed_t prevz;
+    angle_t prevangle;
+
+
     // Interaction info, by BLOCKMAP.
     // Links in blocks (if needed).
     struct mobj_s *bnext;

--- a/FASTDOOM/p_pspr.c
+++ b/FASTDOOM/p_pspr.c
@@ -469,6 +469,7 @@ void A_Punch(player_t *player,
     if (linetarget)
     {
         S_StartSound(players_mo, sfx_punch);
+        players_mo->prevangle = players_mo->angle;
         players_mo->angle = R_PointToAngle2(players_mo->x,
                                             players_mo->y,
                                             linetarget->x,
@@ -501,7 +502,7 @@ void A_Saw(player_t *player,
         return;
     }
     S_StartSound(players_mo, sfx_sawhit);
-
+    players_mo->prevangle = players_mo->angle;
     // turn to face target
     angle = R_PointToAngle2(players_mo->x, players_mo->y,
                             linetarget->x, linetarget->y);

--- a/FASTDOOM/p_setup.c
+++ b/FASTDOOM/p_setup.c
@@ -219,7 +219,9 @@ void P_LoadSectors(int lump)
     for (i = 0; i < numsectors; i++, ss++, ms++)
     {
         ss->floorheight = ms->floorheight << FRACBITS;
+        ss->prevfloorheight = ss->floorheight;
         ss->ceilingheight = ms->ceilingheight << FRACBITS;
+        ss->prevceilingheight = ss->ceilingheight;
         ss->floorpic = R_FlatNumForName(ms->floorpic);
         ss->ceilingpic = R_FlatNumForName(ms->ceilingpic);
         ss->lightlevel = ms->lightlevel;

--- a/FASTDOOM/p_setup.c
+++ b/FASTDOOM/p_setup.c
@@ -37,6 +37,7 @@
 #include "s_sound.h"
 
 #include "doomstat.h"
+#include "i_debug.h"
 
 void P_SpawnMapThing(mapthing_t *mthing);
 
@@ -580,6 +581,7 @@ void P_SetupLevel(int episode,
     // Initial height of PointOfView
     // will be set by player think.
     players.viewz = 1;
+    players.prevviewz = 1;
 
     // Make sure all sounds are stopped before Z_FreeTags.
     S_Start();

--- a/FASTDOOM/p_sight.c
+++ b/FASTDOOM/p_sight.c
@@ -20,6 +20,7 @@
 #include "options.h"
 #include "doomdef.h"
 
+#include "i_debug.h"
 #include "i_system.h"
 #include "p_local.h"
 
@@ -309,9 +310,11 @@ byte P_CheckSight(mobj_t *t1, mobj_t *t2)
     // First check for trivial rejection.
 
     // Determine subsector entries in REJECT table.
-    pnum = Div84((int)t1->subsector->sector - (int)sectors);
+    // NOTE if the size of sector_t changes, this must be changed.
+    ASSERT(sizeof(sector_t) == 128);
+    pnum = Div128((int)t1->subsector->sector - (int)sectors);
     pnum *= numsectors;
-    pnum += Div84((int)t2->subsector->sector - (int)sectors);
+    pnum += Div128((int)t2->subsector->sector - (int)sectors);
     bytenum = pnum >> 3;
     bitnum = 1 << (pnum & 7);
 

--- a/FASTDOOM/p_telept.c
+++ b/FASTDOOM/p_telept.c
@@ -92,8 +92,10 @@ int EV_Teleport(line_t *line, byte side, mobj_t *thing)
 					thing->z = thing->floorz;
 				}
 
-				if (thing->player)
+				if (thing->player) {
 					thing->player->viewz = thing->z + thing->player->viewheight;
+					thing->player->prevviewz = thing->player->viewz;
+				}
 
 				// spawn teleport fog at source and destination
 				fog = P_SpawnMobj(oldx, oldy, oldz, MT_TFOG);

--- a/FASTDOOM/p_user.c
+++ b/FASTDOOM/p_user.c
@@ -69,7 +69,6 @@ void P_CalcHeight(void)
 	players.bob >>= 2;
 	if (players.bob > MAXBOB)
 		players.bob = MAXBOB;
-
 	if (!onground)
 	{
 		players.viewz = players_mo->z + VIEWHEIGHT;
@@ -122,7 +121,6 @@ void P_MovePlayer(void)
 	ticcmd_t *cmd;
 
 	cmd = &players.cmd;
-
 	players_mo->angle += cmd->angleturn;
 
 	// Do not let the player control movement
@@ -176,7 +174,6 @@ void P_DeathThink(void)
 								players.attacker->y);
 
 		delta = angle - players_mo->angle;
-
 		if (delta < ANG5 || delta > (unsigned)-ANG5)
 		{
 			// Looking at killer,

--- a/FASTDOOM/p_user.c
+++ b/FASTDOOM/p_user.c
@@ -22,6 +22,7 @@
 #include "d_event.h"
 #include "options.h"
 #include "p_local.h"
+#include "i_debug.h"
 
 #include "doomstat.h"
 

--- a/FASTDOOM/r_bsp.c
+++ b/FASTDOOM/r_bsp.c
@@ -456,10 +456,10 @@ void R_Subsector(int num)
     frontsector = sub->sector;
 
     if (frontsector->floorheight < viewz)
-        floorplane = R_FindPlane(frontsector->floorheight, frontsector->floorpic, frontsector->lightlevel);
+        floorplane = R_FindPlane(frontsector->floorheight, frontsector->prevfloorheight, frontsector->floorpic, frontsector->lightlevel);
 
     if (frontsector->ceilingheight > viewz || frontsector->ceilingpic == skyflatnum)
-        ceilingplane = R_FindPlane(frontsector->ceilingheight, frontsector->ceilingpic, frontsector->lightlevel);
+        ceilingplane = R_FindPlane(frontsector->ceilingheight, frontsector->prevceilingheight, frontsector->ceilingpic, frontsector->lightlevel);
 
     R_AddSprites(frontsector);
 

--- a/FASTDOOM/r_defs.h
+++ b/FASTDOOM/r_defs.h
@@ -125,6 +125,7 @@ typedef struct
     short linecount;
     struct line_s **lines; // [linecount] size
 
+    byte _pad[36]; // padding to align to 128 bytes
 } sector_t;
 
 //

--- a/FASTDOOM/r_defs.h
+++ b/FASTDOOM/r_defs.h
@@ -91,6 +91,10 @@ typedef struct
 {
     fixed_t floorheight;
     fixed_t ceilingheight;
+    // Used for interpolation since there are lots of animations (doors, lifts, etc.)
+    // which use these fields.
+    fixed_t prevfloorheight;
+    fixed_t prevceilingheight;
     short floorpic;
     short ceilingpic;
     short lightlevel;

--- a/FASTDOOM/r_main.c
+++ b/FASTDOOM/r_main.c
@@ -79,7 +79,6 @@ int detailshift;
 
 
 fixed_t interpolationweight;
-unsigned int lastframetime; // This is in unites of 1/560th of a second
 
 // The viewangletox[viewangle + FINEANGLES/4] lookup
 // maps the visible view angles to screen X coordinates,

--- a/FASTDOOM/r_main.c
+++ b/FASTDOOM/r_main.c
@@ -2876,18 +2876,6 @@ void R_SetupFrame(void)
 
     if (uncappedFPS)
     {
-      signed angle_diff = (players_mo)->angle - (players_mo)->prevangle;
-      signed angle_offset;
-      // Perform frame interpolation. gameticstart is the ticcount_hr
-      // of the last gametic
-      unsigned int new_frametime = ticcount_hr;
-      unsigned int frametime = new_frametime - lastframetime;
-      lastframetime = new_frametime;
-      interpolationweight = (ticcount_hr - gameticstart + frametime) << 12;
-      if (interpolationweight > 0x10000) {
-        interpolationweight = 0x10000;
-      }
-      // Adjust the weight by the last frame time
       viewx = FixedInterpolate(players_mo->prevx, players_mo->x, interpolationweight);
       viewy = FixedInterpolate(players_mo->prevy, players_mo->y, interpolationweight);
       viewangle = (players_mo)->prevangle + ((((signed)(players_mo)->angle - (signed)(players_mo)->prevangle) * ((signed)(interpolationweight>>12)) / 16));

--- a/FASTDOOM/r_main.c
+++ b/FASTDOOM/r_main.c
@@ -2874,7 +2874,7 @@ void R_SetupFrame(void)
 {
     int i;
 
-    if (uncappedFPS)
+    if (highResTimer)
     {
       viewx = FixedInterpolate(players_mo->prevx, players_mo->x, interpolation_weight);
       viewy = FixedInterpolate(players_mo->prevy, players_mo->y, interpolation_weight);

--- a/FASTDOOM/r_main.c
+++ b/FASTDOOM/r_main.c
@@ -2880,7 +2880,6 @@ void R_SetupFrame(void)
       viewy = FixedInterpolate(players_mo->prevy, players_mo->y, interpolation_weight);
       viewangle = (players_mo)->prevangle + ((((signed)(players_mo)->angle - (signed)(players_mo)->prevangle) * ((signed)(interpolation_weight>>12)) / 16));
       viewz = FixedInterpolate(players.prevviewz, players.viewz, interpolation_weight);
-      I_Printf("interpolation_weight: %p, viewz: %p, prevviewz: %p\n", interpolation_weight, players.viewz, players.prevviewz);
     } else {
       // No interpolation
       viewx = (players_mo)->x;

--- a/FASTDOOM/r_main.c
+++ b/FASTDOOM/r_main.c
@@ -78,7 +78,8 @@ int detailshift;
 
 
 
-fixed_t interpolationweight;
+fixed_t interpolation_weight = 0x10000;
+unsigned frametime_hrticks = 17;
 
 // The viewangletox[viewangle + FINEANGLES/4] lookup
 // maps the visible view angles to screen X coordinates,
@@ -2875,10 +2876,11 @@ void R_SetupFrame(void)
 
     if (uncappedFPS)
     {
-      viewx = FixedInterpolate(players_mo->prevx, players_mo->x, interpolationweight);
-      viewy = FixedInterpolate(players_mo->prevy, players_mo->y, interpolationweight);
-      viewangle = (players_mo)->prevangle + ((((signed)(players_mo)->angle - (signed)(players_mo)->prevangle) * ((signed)(interpolationweight>>12)) / 16));
-      viewz = FixedInterpolate(players.prevviewz, players.viewz, interpolationweight);
+      viewx = FixedInterpolate(players_mo->prevx, players_mo->x, interpolation_weight);
+      viewy = FixedInterpolate(players_mo->prevy, players_mo->y, interpolation_weight);
+      viewangle = (players_mo)->prevangle + ((((signed)(players_mo)->angle - (signed)(players_mo)->prevangle) * ((signed)(interpolation_weight>>12)) / 16));
+      viewz = FixedInterpolate(players.prevviewz, players.viewz, interpolation_weight);
+      I_Printf("interpolation_weight: %p, viewz: %p, prevviewz: %p\n", interpolation_weight, players.viewz, players.prevviewz);
     } else {
       // No interpolation
       viewx = (players_mo)->x;

--- a/FASTDOOM/r_main.h
+++ b/FASTDOOM/r_main.h
@@ -51,7 +51,9 @@ extern int validcount;
 
 // When interpolation is enabled (uncappedFPS), this is the weight of the
 // current frame. It is 1.0 (IE 0x10000) when the frame is not interpolated.
-extern fixed_t interpolationweight;
+extern fixed_t interpolation_weight;
+// The last frame render time in units of 1/560ths of a second
+extern unsigned frametime_hrticks;
 
 //
 // Lighting LUT.

--- a/FASTDOOM/r_main.h
+++ b/FASTDOOM/r_main.h
@@ -52,8 +52,6 @@ extern int validcount;
 // When interpolation is enabled (uncappedFPS), this is the weight of the
 // current frame. It is 1.0 (IE 0x10000) when the frame is not interpolated.
 extern fixed_t interpolationweight;
-// The HR timer value of the last frame, used to calculate the interpolation
-extern unsigned int lastframetime;
 
 //
 // Lighting LUT.

--- a/FASTDOOM/r_main.h
+++ b/FASTDOOM/r_main.h
@@ -52,6 +52,8 @@ extern int validcount;
 // When interpolation is enabled (uncappedFPS), this is the weight of the
 // current frame. It is 1.0 (IE 0x10000) when the frame is not interpolated.
 extern fixed_t interpolationweight;
+// The HR timer value of the last frame, used to calculate the interpolation
+extern unsigned int lastframetime;
 
 //
 // Lighting LUT.

--- a/FASTDOOM/r_main.h
+++ b/FASTDOOM/r_main.h
@@ -49,6 +49,10 @@ extern fixed_t projection;
 
 extern int validcount;
 
+// When interpolation is enabled (uncappedFPS), this is the weight of the
+// current frame. It is 1.0 (IE 0x10000) when the frame is not interpolated.
+extern fixed_t interpolationweight;
+
 //
 // Lighting LUT.
 // Used for z-depth cuing per column/row,

--- a/FASTDOOM/r_plane.c
+++ b/FASTDOOM/r_plane.c
@@ -295,7 +295,7 @@ visplane_t *R_FindPlane(fixed_t height, fixed_t prevheight, int picnum, int ligh
         return check;
 
     lastvisplane++;
-    if (uncappedFPS) {
+    if (highResTimer) {
       check->height = FixedInterpolate(prevheight, height, interpolation_weight);
     } else {
       check->height = height;

--- a/FASTDOOM/r_plane.c
+++ b/FASTDOOM/r_plane.c
@@ -296,7 +296,7 @@ visplane_t *R_FindPlane(fixed_t height, fixed_t prevheight, int picnum, int ligh
 
     lastvisplane++;
     if (uncappedFPS) {
-      check->height = FixedInterpolate(prevheight, height, interpolationweight);
+      check->height = FixedInterpolate(prevheight, height, interpolation_weight);
     } else {
       check->height = height;
     }

--- a/FASTDOOM/r_plane.c
+++ b/FASTDOOM/r_plane.c
@@ -273,7 +273,7 @@ short skytexture;
 //
 // R_FindPlane
 //
-visplane_t *R_FindPlane(fixed_t height, int picnum, int lightlevel)
+visplane_t *R_FindPlane(fixed_t height, fixed_t prevheight, int picnum, int lightlevel)
 {
     visplane_t *check;
 
@@ -295,8 +295,11 @@ visplane_t *R_FindPlane(fixed_t height, int picnum, int lightlevel)
         return check;
 
     lastvisplane++;
-
-    check->height = height;
+    if (uncappedFPS) {
+      check->height = FixedInterpolate(prevheight, height, interpolationweight);
+    } else {
+      check->height = height;
+    }
     check->picnum = picnum;
     check->lightlevel = lightlevel;
     check->minx = SCREENWIDTH;

--- a/FASTDOOM/r_plane.h
+++ b/FASTDOOM/r_plane.h
@@ -56,7 +56,7 @@ void R_DrawSkyFlat(visplane_t *pl);
 void R_DrawSkyFlatPlanar(visplane_t *pl);
 void R_DrawSkyFlatPlanarLow(visplane_t *pl);
 
-visplane_t * R_FindPlane(fixed_t height, int picnum, int lightlevel);
+visplane_t * R_FindPlane(fixed_t height, fixed_t prevheight, int picnum, int lightlevel);
 visplane_t * R_CheckPlane(visplane_t *pl, int start, int stop);
 
 #endif

--- a/FASTDOOM/r_segs.c
+++ b/FASTDOOM/r_segs.c
@@ -2293,7 +2293,7 @@ void R_StoreWallRange(int start,
 	fixed_t backsector_floorheight;
 	fixed_t backsector_ceilingheight;
 
-	if (uncappedFPS) {
+	if (highResTimer) {
 		frontsector_floorheight = FixedInterpolate(frontsector->prevfloorheight, frontsector->floorheight, interpolation_weight);
 		frontsector_ceilingheight = FixedInterpolate(frontsector->prevceilingheight, frontsector->ceilingheight, interpolation_weight);
 		backsector_floorheight = FixedInterpolate(backsector->prevfloorheight, backsector->floorheight, interpolation_weight);

--- a/FASTDOOM/r_segs.c
+++ b/FASTDOOM/r_segs.c
@@ -2294,10 +2294,10 @@ void R_StoreWallRange(int start,
 	fixed_t backsector_ceilingheight;
 
 	if (uncappedFPS) {
-		frontsector_floorheight = FixedInterpolate(frontsector->prevfloorheight, frontsector->floorheight, interpolationweight);
-		frontsector_ceilingheight = FixedInterpolate(frontsector->prevceilingheight, frontsector->ceilingheight, interpolationweight);
-		backsector_floorheight = FixedInterpolate(backsector->prevfloorheight, backsector->floorheight, interpolationweight);
-		backsector_ceilingheight = FixedInterpolate(backsector->prevceilingheight, backsector->ceilingheight, interpolationweight);
+		frontsector_floorheight = FixedInterpolate(frontsector->prevfloorheight, frontsector->floorheight, interpolation_weight);
+		frontsector_ceilingheight = FixedInterpolate(frontsector->prevceilingheight, frontsector->ceilingheight, interpolation_weight);
+		backsector_floorheight = FixedInterpolate(backsector->prevfloorheight, backsector->floorheight, interpolation_weight);
+		backsector_ceilingheight = FixedInterpolate(backsector->prevceilingheight, backsector->ceilingheight, interpolation_weight);
 	} else {
 		frontsector_floorheight = frontsector->floorheight;
 		frontsector_ceilingheight = frontsector->ceilingheight;

--- a/FASTDOOM/r_segs.c
+++ b/FASTDOOM/r_segs.c
@@ -29,6 +29,7 @@
 #include "z_zone.h"
 
 #include "std_func.h"
+#include "i_debug.h"
 
 #include <conio.h>
 
@@ -2280,10 +2281,29 @@ void R_RenderSegLoopFlatter(void)
 void R_StoreWallRange(int start,
 					  int stop)
 {
+
 	fixed_t hyp;
 	angle_t distangle, offsetangle;
 	fixed_t vtop;
 	int lightnum;
+
+
+	fixed_t frontsector_floorheight;
+	fixed_t frontsector_ceilingheight;
+	fixed_t backsector_floorheight;
+	fixed_t backsector_ceilingheight;
+
+	if (uncappedFPS) {
+		frontsector_floorheight = FixedInterpolate(frontsector->prevfloorheight, frontsector->floorheight, interpolationweight);
+		frontsector_ceilingheight = FixedInterpolate(frontsector->prevceilingheight, frontsector->ceilingheight, interpolationweight);
+		backsector_floorheight = FixedInterpolate(backsector->prevfloorheight, backsector->floorheight, interpolationweight);
+		backsector_ceilingheight = FixedInterpolate(backsector->prevceilingheight, backsector->ceilingheight, interpolationweight);
+	} else {
+		frontsector_floorheight = frontsector->floorheight;
+		frontsector_ceilingheight = frontsector->ceilingheight;
+		backsector_floorheight = backsector->floorheight;
+		backsector_ceilingheight = backsector->ceilingheight;
+	}
 
 	// don't overflow and crash
 	if (ds_p == &drawsegs[MAXDRAWSEGS])
@@ -2325,8 +2345,8 @@ void R_StoreWallRange(int start,
 
 	// calculate texture boundaries
 	//  and decide if floor / ceiling marks are needed
-	worldtop = frontsector->ceilingheight - viewz;
-	worldbottom = frontsector->floorheight - viewz;
+	worldtop = frontsector_ceilingheight - viewz;
+	worldbottom = frontsector_floorheight - viewz;
 
 	midtexture = toptexture = bottomtexture = maskedtexture = 0;
 	ds_p->maskedtexturecol = NULL;
@@ -2339,7 +2359,7 @@ void R_StoreWallRange(int start,
 		markfloor = markceiling = 1;
 		if (linedef->dontPegBottom)
 		{
-			vtop = frontsector->floorheight +
+			vtop = frontsector_floorheight +
 				   textureheight[sidedef->midtexture];
 			// bottom of texture at bottom
 			rw_midtexturemid = vtop - viewz;
@@ -2363,44 +2383,44 @@ void R_StoreWallRange(int start,
 		ds_p->sprtopclip = ds_p->sprbottomclip = NULL;
 		ds_p->silhouette = SIL_NONE;
 
-		if (frontsector->floorheight > backsector->floorheight)
+		if (frontsector_floorheight > backsector_floorheight)
 		{
 			ds_p->silhouette = SIL_BOTTOM;
-			ds_p->bsilheight = frontsector->floorheight;
+			ds_p->bsilheight = frontsector_floorheight;
 		}
-		else if (backsector->floorheight > viewz)
+		else if (backsector_floorheight > viewz)
 		{
 			ds_p->silhouette = SIL_BOTTOM;
 			ds_p->bsilheight = MAXINT;
 		}
 
-		if (frontsector->ceilingheight < backsector->ceilingheight)
+		if (frontsector_ceilingheight < backsector_ceilingheight)
 		{
 			ds_p->silhouette |= SIL_TOP;
-			ds_p->tsilheight = frontsector->ceilingheight;
+			ds_p->tsilheight = frontsector_ceilingheight;
 		}
-		else if (backsector->ceilingheight < viewz)
+		else if (backsector_ceilingheight < viewz)
 		{
 			ds_p->silhouette |= SIL_TOP;
 			ds_p->tsilheight = MININT;
 		}
 
-		if (backsector->ceilingheight <= frontsector->floorheight)
+		if (backsector_ceilingheight <= frontsector_floorheight)
 		{
 			ds_p->sprbottomclip = negonearray;
 			ds_p->bsilheight = MAXINT;
 			ds_p->silhouette |= SIL_BOTTOM;
 		}
 
-		if (backsector->floorheight >= frontsector->ceilingheight)
+		if (backsector_floorheight >= frontsector_ceilingheight)
 		{
 			ds_p->sprtopclip = screenheightarray;
 			ds_p->tsilheight = MININT;
 			ds_p->silhouette |= SIL_TOP;
 		}
 
-		worldhigh = backsector->ceilingheight - viewz;
-		worldlow = backsector->floorheight - viewz;
+		worldhigh = backsector_ceilingheight - viewz;
+		worldlow = backsector_floorheight - viewz;
 
 		// hack to allow height changes in outdoor areas
 		if (frontsector->ceilingpic == skyflatnum && backsector->ceilingpic == skyflatnum)
@@ -2411,7 +2431,7 @@ void R_StoreWallRange(int start,
 		markfloor = worldlow != worldbottom || backsector->floorpic != frontsector->floorpic || backsector->lightlevel != frontsector->lightlevel;
 		markceiling = worldhigh != worldtop || backsector->ceilingpic != frontsector->ceilingpic || backsector->lightlevel != frontsector->lightlevel;
 
-		if (backsector->ceilingheight <= frontsector->floorheight || backsector->floorheight >= frontsector->ceilingheight)
+		if (backsector_ceilingheight <= frontsector_floorheight || backsector_floorheight >= frontsector_ceilingheight)
 		{
 			// closed door
 			markceiling = markfloor = 1;
@@ -2428,7 +2448,7 @@ void R_StoreWallRange(int start,
 			}
 			else
 			{
-				vtop = backsector->ceilingheight + textureheight[sidedef->toptexture];
+				vtop = backsector_ceilingheight + textureheight[sidedef->toptexture];
 
 				// bottom of texture
 				rw_toptexturemid = vtop - viewz;
@@ -2506,13 +2526,13 @@ void R_StoreWallRange(int start,
 	//  of the view plane, it is definitely invisible
 	//  and doesn't need to be marked.
 
-	if (frontsector->floorheight >= viewz)
+	if (frontsector_floorheight >= viewz)
 	{
 		// above view plane
 		markfloor = 0;
 	}
 
-	if (frontsector->ceilingheight <= viewz && frontsector->ceilingpic != skyflatnum)
+	if (frontsector_ceilingheight <= viewz && frontsector->ceilingpic != skyflatnum)
 	{
 		// below view plane
 		markceiling = 0;

--- a/FASTDOOM/r_things.c
+++ b/FASTDOOM/r_things.c
@@ -1103,7 +1103,7 @@ void R_ProjectSprite(mobj_t *thing)
     fixed_t y;
     fixed_t z;
 
-    if (uncappedFPS) {
+    if (highResTimer) {
       // Interpolate the position of the thing
       x = FixedInterpolate(thing->prevx, thing->x, interpolation_weight);
       y = FixedInterpolate(thing->prevy, thing->y, interpolation_weight);

--- a/FASTDOOM/r_things.c
+++ b/FASTDOOM/r_things.c
@@ -1105,9 +1105,9 @@ void R_ProjectSprite(mobj_t *thing)
 
     if (uncappedFPS) {
       // Interpolate the position of the thing
-      x = FixedInterpolate(thing->prevx, thing->x, interpolationweight);
-      y = FixedInterpolate(thing->prevy, thing->y, interpolationweight);
-      z = FixedInterpolate(thing->prevz, thing->z, interpolationweight);
+      x = FixedInterpolate(thing->prevx, thing->x, interpolation_weight);
+      y = FixedInterpolate(thing->prevy, thing->y, interpolation_weight);
+      z = FixedInterpolate(thing->prevz, thing->z, interpolation_weight);
     } else {
       x = thing->x;
       y = thing->y;

--- a/FASTDOOM/r_things.c
+++ b/FASTDOOM/r_things.c
@@ -35,6 +35,8 @@
 
 #include <conio.h>
 
+#include "i_debug.h"
+
 #include "sizeopt.h"
 
 #define SC_INDEX 0x3C4
@@ -1097,9 +1099,24 @@ void R_ProjectSprite(mobj_t *thing)
     angle_t ang;
     fixed_t iscale;
 
+    fixed_t x;
+    fixed_t y;
+    fixed_t z;
+
+    if (uncappedFPS) {
+      // Interpolate the position of the thing
+      x = FixedInterpolate(thing->prevx, thing->x, interpolationweight);
+      y = FixedInterpolate(thing->prevy, thing->y, interpolationweight);
+      z = FixedInterpolate(thing->prevz, thing->z, interpolationweight);
+    } else {
+      x = thing->x;
+      y = thing->y;
+      z = thing->z;
+    }
+
     // transform the origin point
-    tr_x = thing->x - viewx;
-    tr_y = thing->y - viewy;
+    tr_x = x - viewx;
+    tr_y = y - viewy;
 
     if (nearSprites && !(thing->flags & MF_SHOOTABLE) && (abs(tr_x) > 40000000 || abs(tr_y) > 40000000))
         return;
@@ -1162,10 +1179,10 @@ void R_ProjectSprite(mobj_t *thing)
     // killough 4/9/98: clip things which are out of view due to height
     // viti95 6/6/20: optimize by removing divisions and using multiplications instead. Also discard first than calculate other things.
 
-    if (FixedMul(thing->z - viewz, xscale) > viewheightshift)
+    if (FixedMul(z - viewz, xscale) > viewheightshift)
         return;
 
-    gzt = thing->z + spritetopoffset[lump];
+    gzt = z + spritetopoffset[lump];
 
     if (viewheightopt < FixedMul(viewz - gzt, xscale))
         return;
@@ -1207,9 +1224,9 @@ void R_ProjectSprite(mobj_t *thing)
     vis->scale = xscale;
 #endif
 
-    vis->gx = thing->x;
-    vis->gy = thing->y;
-    vis->gz = thing->z;
+    vis->gx = x;
+    vis->gy = y;
+    vis->gz = z;
     vis->gzt = gzt; // killough 3/27/98
     vis->texturemid = gzt - viewz;
     vis->x1 = x1 < 0 ? 0 : x1;

--- a/FDSETUP/DEFAULT.C
+++ b/FDSETUP/DEFAULT.C
@@ -30,6 +30,7 @@ int showFPS = 0;
 int debugCardPort = 0x80;
 int debugCardReverse = 0;
 int busSpeed = 0;
+int uncappedFPS = 0;
 int flatSky = 0;
 int nearSprites = 0;
 int noMelt = 0;
@@ -72,6 +73,7 @@ default_t defaults[] =
 		{"debugCardPort", &debugCardPort, 0x80},
 		{"debugCardReverse", &debugCardReverse, 0},
 		{"busSpeed", &busSpeed, 0},
+    {"uncappedFPS", &uncappedFPS, 0},
 		{"flatsky", &flatSky, 0},
 		{"near", &nearSprites, 0},
 		{"nomelt", &noMelt, 0},

--- a/FDSETUP/DEFAULT.C
+++ b/FDSETUP/DEFAULT.C
@@ -73,7 +73,7 @@ default_t defaults[] =
 		{"debugCardPort", &debugCardPort, 0x80},
 		{"debugCardReverse", &debugCardReverse, 0},
 		{"busSpeed", &busSpeed, 0},
-    {"uncappedFPS", &uncappedFPS, 0},
+    	{"uncappedFPS", &uncappedFPS, 0},
 		{"flatsky", &flatSky, 0},
 		{"near", &nearSprites, 0},
 		{"nomelt", &noMelt, 0},


### PR DESCRIPTION
Changes needed to accomplish this:
- Readded uncapped FPS option
- Increased the timer interrupt from 35 Hz to 560 Hz (x16)
- Added interpolation to sprite, view, and floor/cieling routines.

This saves the following values between two gametics:

- All things (m_objt) x, y, and z positions, includes the player
- All sectors ceiling and floor heights.
- Player viewz

Values are only saved when uncappedFPS is enabled.

Known bugs:
- When on lifts, the interpolation is not quite correct. Doors seem
  correct, which uses the same code, so there is some interaction with
  viewz perhaps that is problematic.
- There is something off with the menu rendering with the extra option

This will allow work to proceed to handle #140 with custom refresh rates
that better accommodate modern displays

In addition, in my previous PR, I had intended to include dbgcfg.h which was a file for setting debug output options. I include it here in this PR.

@viti95 Happy to address any questions or issues