### PR TITLE
feat: add option to limit memory to 32Mb

### DIFF
--- a/FASTDOOM/d_main.c
+++ b/FASTDOOM/d_main.c
@@ -93,6 +93,8 @@ char *wadfiles[MAXWADFILES];
 boolean respawnparm; // checkparm of -respawn
 boolean fastparm;    // checkparm of -fast
 
+boolean limitram; // checkparm of -limitram
+
 boolean flatSky;
 int invisibleRender;
 int visplaneRender;
@@ -1255,6 +1257,11 @@ void D_DoomMain(void)
     union REGS regs;
 
     printf("\nFastDoom version " FDOOMVERSION "\n\n");
+    limitram = M_CheckParm("-limitram");
+    if (limitram) {
+        printf("\nLimiting RAM for larger systems... ");
+    }
+
     Z_Init();
 
     p = M_CheckParm("-iwad");

--- a/FASTDOOM/d_main.c
+++ b/FASTDOOM/d_main.c
@@ -1264,7 +1264,6 @@ void D_DoomMain(void)
     {
         if (p < myargc - 1) {
             limitram = atoi(myargv[p + 1]);
-            printf("\nLimiting max used RAM... ");
         }
     }
 
@@ -1273,7 +1272,6 @@ void D_DoomMain(void)
     {
         if (p < myargc - 1) {
             freeram = atoi(myargv[p + 1]);
-            printf("\nLeaving free RAM");
         }
     }
 

--- a/FASTDOOM/d_main.c
+++ b/FASTDOOM/d_main.c
@@ -93,7 +93,8 @@ char *wadfiles[MAXWADFILES];
 boolean respawnparm; // checkparm of -respawn
 boolean fastparm;    // checkparm of -fast
 
-boolean limitram; // checkparm of -limitram
+unsigned int limitram; // checkparm of -limitram
+unsigned int freeram; // checkparm of -freeram
 
 boolean flatSky;
 int invisibleRender;
@@ -1257,9 +1258,23 @@ void D_DoomMain(void)
     union REGS regs;
 
     printf("\nFastDoom version " FDOOMVERSION "\n\n");
-    limitram = M_CheckParm("-limitram");
-    if (limitram) {
-        printf("\nLimiting RAM for larger systems... ");
+
+    p = M_CheckParm("-limitram");
+    if (p)
+    {
+        if (p < myargc - 1) {
+            limitram = atoi(myargv[p + 1]);
+            printf("\nLimiting max used RAM... ");
+        }
+    }
+
+    p = M_CheckParm("-freeram");
+    if (p)
+    {
+        if (p < myargc - 1) {
+            freeram = atoi(myargv[p + 1]);
+            printf("\nLeaving free RAM");
+        }
     }
 
     Z_Init();

--- a/FASTDOOM/d_main.c
+++ b/FASTDOOM/d_main.c
@@ -1258,7 +1258,7 @@ void D_DoomMain(void)
 
     printf("\nFastDoom version " FDOOMVERSION "\n\n");
     limitram = M_CheckParm("-limitram");
-    if (limitram) {
+    if (limitram && heap > 32768000) {
         printf("\nLimiting RAM for larger systems... ");
     }
 

--- a/FASTDOOM/d_main.c
+++ b/FASTDOOM/d_main.c
@@ -1258,7 +1258,7 @@ void D_DoomMain(void)
 
     printf("\nFastDoom version " FDOOMVERSION "\n\n");
     limitram = M_CheckParm("-limitram");
-    if (limitram && heap > 32768000) {
+    if (limitram) {
         printf("\nLimiting RAM for larger systems... ");
     }
 

--- a/FASTDOOM/d_main.h
+++ b/FASTDOOM/d_main.h
@@ -39,6 +39,7 @@ void D_DoomLoopBenchmark(void);
 
 extern unsigned int frametime_position;
 extern unsigned int *frametime;
+extern boolean limitram;
 
 
 // Called by IO functions when input is detected.

--- a/FASTDOOM/d_main.h
+++ b/FASTDOOM/d_main.h
@@ -39,7 +39,9 @@ void D_DoomLoopBenchmark(void);
 
 extern unsigned int frametime_position;
 extern unsigned int *frametime;
-extern boolean limitram;
+
+extern unsigned int limitram;
+extern unsigned int freeram;
 
 
 // Called by IO functions when input is detected.

--- a/FASTDOOM/i_ibm.c
+++ b/FASTDOOM/i_ibm.c
@@ -1102,6 +1102,10 @@ byte *I_ZoneBase(int *size)
     int386x(0x31, &regs, &regs, &segregs);
 
     heap = meminfo[0];
+    // magic number: limit memory
+    if (heap > 32768000) {
+        heap = 32768000;
+    }
     printf("Available DPMI memory: %d Kb\n", heap >> 10);
 
     heap -= 0x4000; // leave 16kb free

--- a/FASTDOOM/i_ibm.c
+++ b/FASTDOOM/i_ibm.c
@@ -1102,8 +1102,8 @@ byte *I_ZoneBase(int *size)
     int386x(0x31, &regs, &regs, &segregs);
 
     heap = meminfo[0];
-    // magic number: limit memory
-    if (heap > 32768000) {
+    // magic number: limit memory to 32MB
+    if (limitram) {
         heap = 32768000;
     }
     printf("Available DPMI memory: %d Kb\n", heap >> 10);

--- a/FASTDOOM/i_ibm.c
+++ b/FASTDOOM/i_ibm.c
@@ -1102,13 +1102,15 @@ byte *I_ZoneBase(int *size)
     int386x(0x31, &regs, &regs, &segregs);
 
     heap = meminfo[0];
-    // magic number: limit memory to 32MB
-    if (limitram && heap > 32768000) {
-        heap = 32768000;
-    }
-    printf("Available DPMI memory: %d Kb\n", heap >> 10);
 
-    heap -= 0x4000; // leave 16kb free
+    if (limitram && limitram <= heap) {
+        heap = limitram * 1000;
+    }
+    printf("\nAvailable DPMI memory: %d Kb\n", heap >> 10);
+
+    if (freeram && (heap - freeram) > 0) {
+        heap -= freeram * 1000; // leave N free ram
+    }
 
     do
     {

--- a/FASTDOOM/i_ibm.c
+++ b/FASTDOOM/i_ibm.c
@@ -1103,7 +1103,7 @@ byte *I_ZoneBase(int *size)
 
     heap = meminfo[0];
     // magic number: limit memory to 32MB
-    if (limitram) {
+    if (limitram && heap > 32768000) {
         heap = 32768000;
     }
     printf("Available DPMI memory: %d Kb\n", heap >> 10);

--- a/FASTDOOM/i_ibm.c
+++ b/FASTDOOM/i_ibm.c
@@ -1103,13 +1103,14 @@ byte *I_ZoneBase(int *size)
 
     heap = meminfo[0];
 
-    if (limitram && limitram <= heap) {
-        heap = limitram * 1000;
-    }
     printf("\nAvailable DPMI memory: %d Kb\n", heap >> 10);
 
-    if (freeram && (heap - freeram) > 0) {
-        heap -= freeram * 1000; // leave N free ram
+    if (limitram && limitram <= heap) {
+        heap = limitram * 1024;
+    } else if (freeram && (heap - freeram) > 0) {
+        heap -= freeram * 1024; // leave N free ram
+    } else {
+        heap -= 0x20000; // Leave 128Kb free by default
     }
 
     do

--- a/README.txt
+++ b/README.txt
@@ -216,6 +216,8 @@
  -cy5x86 => Use Cyrix 5x86 codepath
  -k5 => Use AMD K5 codepath
  -pentium => Use Intel Pentium codepath
+ -limitram 32768 => Limit maximum memory to 32MB
+ -freeram 128 => Leaves 128 KB free
  
  Limitations / Known bugs
  ------------------------


### PR DESCRIPTION
Fixes #195 

For a 256MB system, fdoom.cfg gets erased on fastdoom startup, and thus no sound is available.

I know this is a harsh, magic-number solution, but it's for demonstration purposes.