### PR TITLE
Average of frametime since last second

### DIFF
--- a/FASTDOOM/d_main.c
+++ b/FASTDOOM/d_main.c
@@ -541,8 +541,6 @@ void D_DoomLoop(void)
 
     while (1)
     {
-        frame_ticcount = ticcount;
-
         // process one or more tics
         if (singletics)
         {
@@ -591,7 +589,6 @@ void D_DoomLoopBenchmark(void)
 
     while (1)
     {
-        frame_ticcount = ticcount;
         start_time = mscount;
 
         // process one or more tics

--- a/FASTDOOM/i_ibm.c
+++ b/FASTDOOM/i_ibm.c
@@ -566,47 +566,47 @@ void I_UpdateNoBlit(void)
 
 extern int screenblocks;
 
-#define fps_storage_size 16
-unsigned int stored_fps[fps_storage_size];
-unsigned int fps_array_pos = 0;
-unsigned int frame_ticcount;
+//#define HIGH_PRECISION_FPS
+#define TIMER_RATE 35
+#define MAX_FPS 256 //must be power of 2
+
+unsigned int fps_time[MAX_FPS];
+unsigned int fps_head = 0;
+unsigned int fps_tail = 0;
+unsigned int fps_size = 0;
+
+#ifdef HIGH_PRECISION_FPS
+unsigned int fps_sum = 0;
+#endif
 
 void I_CalculateFPS(void)
 {
-    static unsigned int fps_counter, fps_starttime, fps_nextcalculation, average_fps, smoothness;
-    unsigned int opt1, opt2;
-    unsigned int current_fps;
-    unsigned int total;
-    unsigned int i;
+    unsigned time = ticcount;
 
-    if (fps_counter == 0)
-        fps_starttime = frame_ticcount;
-
-    fps_counter++;
-
-    opt2 = frame_ticcount - fps_starttime;
-
-    if (opt2 != 0)
+    //dequeue old items (older than 1 sec)
+    while ((fps_size > 0 && ((time - fps_time[fps_head]) >= TIMER_RATE))
+        || (fps_size >= MAX_FPS))
     {
-        opt1 = 35 * 10 * (fps_counter - 1);
-        current_fps = opt1 / opt2;
-
-        fps_counter = 0;
-
-        stored_fps[fps_array_pos] = current_fps;
-
-        total = 0;
-        for (i = 0; i < fps_storage_size; i++)
-        {
-            total += stored_fps[i];
-        }
-
-        fps = total / fps_storage_size;
-
-        fps_array_pos++;
-        if (fps_array_pos == fps_storage_size)
-            fps_array_pos = 0;
+        #ifdef HIGH_PRECISION_FPS
+        fps_sum -= fps_time[fps_head] - fps_time[(fps_head + MAX_FPS - 1) % MAX_FPS];
+        #endif
+        fps_head = (fps_head + 1) % MAX_FPS;
+        fps_size--;
     }
+
+    //enqueue new item
+    #ifdef HIGH_PRECISION_FPS
+    fps_sum += time - fps_time[(fps_tail + MAX_FPS - 1) % MAX_FPS];
+    #endif
+    fps_time[fps_tail] = time;
+    fps_tail = (fps_tail + 1) % MAX_FPS;
+    fps_size++;
+
+    #ifdef HIGH_PRECISION_FPS
+    fps = fps_sum == 0 ? 0 : (TIMER_RATE * 10 * fps_size) / fps_sum;
+    #else
+    fps = 10 * fps_size;
+    #endif
 }
 
 //

--- a/FASTDOOM/i_ibm.h
+++ b/FASTDOOM/i_ibm.h
@@ -22,5 +22,3 @@ extern int updatestate;
 extern void I_TimerISR(task *task);
 extern void I_TimerMS(task *task);
 extern void *I_DosMemAlloc(unsigned long size);
-
-extern unsigned int frame_ticcount;


### PR DESCRIPTION
It's based on earlier discussion https://github.com/viti95/FastDoom/discussions/204

The implementation is as simple as it can be : each frame, add current time to a queue, then dequeue elements older than 1 second. FPS is the number of items in the queue. In case of high precision timer, FPS is average of frame times in the queue. Because we remove elements older than 1 second, it's frame rate independent.

- implementation is very fast : there is no division (at least for zero decimal FPS), modulo operation are implemented with masks and the loop will only iterate one time per call in average.
- by default, it show zero decimal FPS. That one is very stable and responsive even with 35 Hz timer.
- in case a higher precision timer is used (in the future), there is a flag `HIGH_PRECISION_FPS` that can be set. It calculate FPS with one decimal. The `TIMER_RATE` constant and `ticcount` variable should be updated accordingly. 

Ideas for the future : 
- use 560 Hz timer implemented by @dougvj, when available 
- add two FPS modes in options menu : one with 35 Hz timer and one with faster timer created/destroyed on the fly. I think tasks module already support that. Or use a single high precision timer that is only created when FPS is on. 1000 Hz timer is clearly an overkill.