### PR TITLE
Use high precision timer for FPS

### DIFF
--- a/FASTDOOM/i_ibm.h
+++ b/FASTDOOM/i_ibm.h
@@ -6,6 +6,7 @@
 extern unsigned int ticcount_hr;
 extern unsigned int ticcount;
 extern unsigned int fps;
+extern boolean uncappedFPS;
 
 extern unsigned short *currentscreen;
 


### PR DESCRIPTION
Use high resolution timer (560 Hz) from @dougvj for counting FPS (when available).
This considerably reduce wiggling, especially at high FPS.

I have also renamed the flag `HIGH_PRECISION_FPS` to `SUB_FRAME_FPS` at it was misleading. Accuracy is linked to timer resolution not the method used. That flag should only be used to get FPS measurement with one decimal or more. Method currently used for no decimal is better suited.