### PR TITLE
Fix issue when fps is higher than FPS_MAX and SUB_FRAME_FPS is enabled

### DIFF
--- a/FASTDOOM/i_ibm.c
+++ b/FASTDOOM/i_ibm.c
@@ -596,7 +596,7 @@ void I_CalculateFPS(void)
 
     //dequeue old items (older than 1 sec)
     while ((fps_size > 0 && ((time - fps_time[fps_head]) >= timer_rate))
-        || (fps_size >= MAX_FPS))
+        || (fps_size >= MAX_FPS-1))
     {
         #ifdef SUB_FRAME_FPS
         fps_sum -= fps_time[fps_head] - fps_time[(fps_head + MAX_FPS - 1) % MAX_FPS];


### PR DESCRIPTION
Summary : when `SUB_FRAME_FPS` is enabled and fps is higher than `FPS_MAX`, fps is no more calculated correctly (usually it become 0). 

This is issue was already spotted in this [PR](https://github.com/viti95/FastDoom/pull/209#issuecomment-2342013555) but it get merged a little too early (and was not included).

Note : after this fix, fps displayed will be max `FPS_MAX-1`, 255 with current settings.
