### PR TITLE
feat: add Dockerfile to support compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Dockerfile multi-arch para Open Watcom v2
+FROM --platform=$BUILDPLATFORM debian:bookworm AS builder
+
+ARG TARGETARCH
+RUN apt-get update && apt-get install -y \
+    git clang make cmake dosbox \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+RUN git clone https://github.com/open-watcom/open-watcom-v2.git
+
+WORKDIR /build/open-watcom-v2
+# Configuración para diferentes arquitecturas
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+    echo "OWTOOLS=GCC" >> setvars.sh; \
+    else \
+    echo "OWTOOLS=CLANG" >> setvars.sh; \
+    fi
+RUN echo "export OWDOSBOX=dosbox" >> setvars.sh
+
+RUN ./build.sh
+RUN ./build.sh rel os_dos
+
+# Etapa final
+FROM debian:bookworm-slim
+COPY --from=builder /build/open-watcom-v2/rel /opt/watcom
+
+ENV WATCOM=/opt/watcom \
+    PATH="$PATH:/opt/watcom/arml64:/opt/watcom/binl" \
+    EDDAT=/opt/watcom/eddat \
+    INCLUDE=/opt/watcom/h
+
+RUN apt-get update && apt-get install -y nasm flatpak 
+RUN flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+
+RUN flatpak install flathub com.dosbox_x.DOSBox-X -y
+# Verificación de instalación
+RUN apt-get install -y 7zip
+RUN find . -name wcl386
+RUN wcl386 -h > /dev/null && echo "Compilador verificado"
+RUN rm -rf /var/lib/apt/lists/*

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+# docker-compose.yml
+version: '3.8'
+
+services:
+  builder:
+    build: .
+    volumes:
+      - .:/app           # Monta el proyecto local
+      - ./dist:/app/dist # Carpeta compartida para resultados
+    working_dir: /app
+    command: /bin/bash -c -e "touch FDOOM1.MAP && touch FDOOMVBR.EXE && source env.sh && ./package.sh && cp FastDoom_*.zip /app/dist"


### PR DESCRIPTION
This Dockerfile eases (a lot!) the compilation of fastdoom, as it just requires the user to execute:
`docker-compose build && docker-compose up`

and it will generate the package at once.

First time will take longer, as it compiles open-watcom-v2. 

* Why not use the precompiled version? I found using the binary caused some issues.
* Why these ARM things? because I wanted to be compatible with Mac Sillicon and AMD64 machines. I haven't tested this black-magic, though, I hope it works.

