### PR TITLE
Add check for fdoom.exe before running stub

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -267,6 +267,12 @@ for param in "$@"; do
     fi
 done
 
+if [ ! -f fdoom.exe ]; then
+  echo "Error: fdoom.exe not found. Build failed."
+  exit 1
+fi
+
+
 if [ "$dostub" = "true" ]; then
   ./stub.sh $target
 fi

--- a/build.sh
+++ b/build.sh
@@ -267,11 +267,10 @@ for param in "$@"; do
     fi
 done
 
-if [ ! -f fdoom.exe ]; then
-  echo "Error: fdoom.exe not found. Build failed."
+if [ ! -f ${target^^} ]; then
+  echo "Error:" ${target^^} "not found. Build failed."
   exit 1
 fi
-
 
 if [ "$dostub" = "true" ]; then
   ./stub.sh $target


### PR DESCRIPTION
Not sure if this was a mistake or intentional but there really should be a check that fast doom actually exists before you say it does.