### PR TITLE
fix: use classical dosbox as it is included in package manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,9 @@ ENV WATCOM=/opt/watcom \
     EDDAT=/opt/watcom/eddat \
     INCLUDE=/opt/watcom/h
 
-RUN apt-get update && apt-get install -y nasm flatpak 
-RUN flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+RUN apt-get update && apt-get install -y nasm 7zip dosbox
 
-RUN flatpak install flathub com.dosbox_x.DOSBox-X -y
 # Verificación de instalación
-RUN apt-get install -y 7zip
 RUN find . -name wcl386
 RUN wcl386 -h > /dev/null && echo "Compilador verificado"
 RUN rm -rf /var/lib/apt/lists/*

--- a/buildall.sh
+++ b/buildall.sh
@@ -9,7 +9,7 @@ build() {
   ./build.sh $1 -clean
 }
 
-rm FDOOM*.EXE FDOOM*.MAP|| true
+rm -f FDOOM*.EXE FDOOM*.MAP|| true
 for target in $build_list;
 do
   build $target

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,4 +8,4 @@ services:
       - .:/app           # Monta el proyecto local
       - ./dist:/app/dist # Carpeta compartida para resultados
     working_dir: /app
-    command: /bin/bash -c -e "touch FDOOM1.MAP && touch FDOOMVBR.EXE && source fdenv.sh && ./package.sh && cp FastDoom_*.zip /app/dist"
+    command: /bin/bash -c -e "source fdenv.sh && ./package.sh && cp FastDoom_*.zip /app/dist"

--- a/stub.sh
+++ b/stub.sh
@@ -54,6 +54,7 @@ if type dosbox &>/dev/null; then
   echo "exit" >> stubdbox.bat
   cat stubdbox.bat 
   SDL_VIDEODRIVER=dummy dosbox  -exit -c "config -set cycles=max" -c "mount J ." -c "J:" -c "SET DOS32A=J:\DOS32A" -c "SET PATH=%PATH%;J:\DOS32A\BINW" -c "stubdbox.bat" &>/dev/null
+  rm -f stubdbox.bat
   kill -TERM $tail_pid
   rm STUB.LOG
   echo "Done"

--- a/stub.sh
+++ b/stub.sh
@@ -44,7 +44,16 @@ echo "Flatpak DOSBox-X not found"
 
 if type dosbox &>/dev/null; then
   echo "Using native DOSBox (classic)"
-  SDL_VIDEODRIVER=dummy dosbox  -exit -c "config -set cycles=max" -c "mount J ." -c "J:" -c "SET DOS32A=J:\DOS32A" -c "SET PATH=%PATH%;J:\DOS32A\BINW" -c "$parameter" &>/dev/null
+  # NOTE: dosbox does not support the advanced for included in stub.bat
+  echo "@echo off" > stubdbox.bat 
+  for f in FDOOM*.EXE FDM*.EXE; do
+      [ -e "$f" ] || continue
+      echo "sb /R $f >> stub.log" >> stubdbox.bat
+      echo "ss $f dos32a.d32 >> stub.log" >> stubdbox.bat
+  done
+  echo "exit" >> stubdbox.bat
+  cat stubdbox.bat 
+  SDL_VIDEODRIVER=dummy dosbox  -exit -c "config -set cycles=max" -c "mount J ." -c "J:" -c "SET DOS32A=J:\DOS32A" -c "SET PATH=%PATH%;J:\DOS32A\BINW" -c "stubdbox.bat" &>/dev/null
   kill -TERM $tail_pid
   rm STUB.LOG
   echo "Done"

--- a/stub.sh
+++ b/stub.sh
@@ -42,4 +42,13 @@ fi
 
 echo "Flatpak DOSBox-X not found"
 
+if type dosbox &>/dev/null; then
+  echo "Using native DOSBox (classic)"
+  SDL_VIDEODRIVER=dummy dosbox  -exit -c "config -set cycles=max" -c "mount J ." -c "J:" -c "SET DOS32A=J:\DOS32A" -c "SET PATH=%PATH%;J:\DOS32A\BINW" -c "$parameter" &>/dev/null
+  kill -TERM $tail_pid
+  rm STUB.LOG
+  echo "Done"
+  exit
+fi
+
 echo "No suitable DOSBox-X installation found. Abort"


### PR DESCRIPTION
Looks like Classic DOS does not support `for %%f in (fdoom*.exe) do`, so it requires modifying stub.sh

I only did for the full build scenario, but it works:
```
builder_1  |
builder_1  | Application Name:   "FDM768R.EXE"
builder_1  | Application Size:   1130556 bytes
builder_1  | Application Type:   Unknown Stub File bound to
builder_1  |                     LE-style file format Linear Executable
builder_1  |
builder_1  |   Unbinding file:   "FDM768R.EXE"
builder_1  | Destination file:   "FDM768R.le"
builder_1  | Destination size:   1130012 bytes (100.0%)
builder_1  |
builder_1  |     Binding file:   "FDM768R.le"
builder_1  | Destination file:   "FDM768R.exe"
builder_1  | Destination size:   1157548 bytes (102.4%)
builder_1  |   Stub file used:   "DOS32A.EXE"
builder_1  | SS/32A -- Configuration Utility version 9.1.2
builder_1  | Copyright (C) 1996-2006 by Narech K.
builder_1  | SS/32A: File "FDM768R.EXE" has been successfully configured
builder_1  | SB/32A -- Bind Utility version 9.1.2
builder_1  | Copyright (C) 1996-2006 by Narech K.
builder_1  |
builder_1  | Application Name:   "FDM800D.EXE"
builder_1  | Application Size:   1126172 bytes
builder_1  | Application Type:   Unknown Stub File bound to
builder_1  |                     LE-style file format Linear Executable
builder_1  |
builder_1  |   Unbinding file:   "FDM800D.EXE"
builder_1  | Destination file:   "FDM800D.le"
builder_1  | Destination size:   1125628 bytes (100.0%)
builder_1  |
builder_1  |     Binding file:   "FDM800D.le"
builder_1  | Destination file:   "FDM800D.exe"
builder_1  | Destination size:   1153164 bytes (102.4%)
builder_1  |   Stub file used:   "DOS32A.EXE"
builder_1  | SS/32A -- Configuration Utility version 9.1.2
builder_1  | Copyright (C) 1996-2006 by Narech K.
builder_1  | SS/32A: File "FDM800D.EXE" has been successfully configured
builder_1  | Done
builder_1  |
builder_1  | 7-Zip (z) 22.01 (arm64) : Copyright (c) 1999-2022 Igor Pavlov : 2022-07-15
builder_1  |  64-bit arm_v:8 locale=C.UTF-8 Threads:4
builder_1  |
builder_1  | Scanning the drive:
builder_1  | 4 folders, 85 files, 38085323 bytes (37 MiB)
builder_1  |
builder_1  | Creating archive: ../FastDoom_1.1.5.zip
builder_1  |
builder_1  | Add new data to archive: 4 folders, 85 files, 38085323 bytes (37 MiB)
builder_1  |
builder_1  |
builder_1  | Files read from disk: 85
builder_1  | Archive size: 16012513 bytes (16 MiB)
builder_1  | Everything is Ok
```