### PR TITLE
XT keyboard code

### DIFF
--- a/FASTDOOM/d_main.c
+++ b/FASTDOOM/d_main.c
@@ -123,6 +123,8 @@ boolean forceLowDetail;
 boolean forcePotatoDetail;
 int forceScreenSize;
 
+boolean xtCompat;
+
 #if defined(TEXT_MODE)
 boolean CGAcard;
 #endif
@@ -1526,6 +1528,8 @@ void D_DoomMain(void)
     reverseStereo = M_CheckParm("-reverseStereo");
 
     csv = M_CheckParm("-csv");
+
+    xtCompat = M_CheckParm("-xt");
 
     benchmark_advanced = M_CheckParm("-advanced");
 

--- a/FASTDOOM/doomstat.h
+++ b/FASTDOOM/doomstat.h
@@ -99,6 +99,8 @@ extern boolean videoPageFix;
 
 extern boolean ignoreSoundChecks;
 
+extern boolean xtCompat;
+
 extern boolean csv;
 extern boolean disableDemo;
 

--- a/FASTDOOM/i_ibm.c
+++ b/FASTDOOM/i_ibm.c
@@ -953,10 +953,18 @@ void(__interrupt __far *oldkeyboardisr)() = NULL;
 
 void __interrupt I_KeyboardISR(void)
 {
+    byte temp;
+
     // Get the scan code
 
     keyboardque[kbdhead & (KBDQUESIZE - 1)] = InByte60h();
     kbdhead++;
+
+    // Tell the XT keyboard controller to clear the key
+
+    temp = InByte61h();
+    OutByte61h(temp | 0x80);
+    OutByte61h(temp);
 
     // acknowledge the interrupt
 

--- a/FASTDOOM/i_ibm.c
+++ b/FASTDOOM/i_ibm.c
@@ -953,6 +953,18 @@ void(__interrupt __far *oldkeyboardisr)() = NULL;
 
 void __interrupt I_KeyboardISR(void)
 {
+    // Get the scan code
+
+    keyboardque[kbdhead & (KBDQUESIZE - 1)] = InByte60h();
+    kbdhead++;
+
+    // acknowledge the interrupt
+
+    OutByte20h(0x20);
+}
+
+void __interrupt I_KeyboardISR_XT(void)
+{
     byte temp;
 
     // Get the scan code
@@ -977,7 +989,14 @@ void __interrupt I_KeyboardISR(void)
 void I_StartupKeyboard(void)
 {
     oldkeyboardisr = _dos_getvect(KEYBOARDINT);
-    _dos_setvect(0x8000 | KEYBOARDINT, I_KeyboardISR);
+
+    if (xtCompat) 
+    {
+        _dos_setvect(0x8000 | KEYBOARDINT, I_KeyboardISR_XT);
+    } else {
+        _dos_setvect(0x8000 | KEYBOARDINT, I_KeyboardISR);
+    }
+    
 }
 
 void I_ShutdownKeyboard(void)


### PR DESCRIPTION
You can put a 486 in an XT and run Doom, but the keyboard won't work according to this [Al's Geek Lab video](https://www.youtube.com/watch?v=Fe1gd-xrNDc&t=830s).

Copying some code from [Commander Keen](https://github.com/keendreams/keen/blob/master/id_in.c#L165) / [Wolfenstein 3D](https://github.com/id-Software/wolf3d/blob/master/WOLFSRC/ID_IN.C#L152) makes it [work](https://bsky.app/profile/alsgeeklab.bsky.social/post/3lwqannnghk2a).