### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ This project exists thanks to all the people who contribute.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=viti95/FastDoom&type=Date)](https://star-history.com/#viti95/FastDoom&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=viti95/FastDoom&type=Date)](https://star-history.dera.page/#viti95/FastDoom&Date)
 
 
 ## Contributing


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions. This change points it to an alternative that works without an API token, so the chart displays correctly again.