### PR TITLE
Use most common color for "flat" rendering of floors/ceilings

### DIFF
--- a/FASTDOOM/defs.inc
+++ b/FASTDOOM/defs.inc
@@ -68,3 +68,4 @@ extern _ds_colormap
 extern _ds_frac
 extern _ds_step
 extern _ds_source
+extern _ds_flatcolor

--- a/FASTDOOM/planar2.asm
+++ b/FASTDOOM/planar2.asm
@@ -352,9 +352,8 @@ CODE_SYM_DEF R_DrawSpanFlat
 	push	edi
 	push	ebp
 	sub		esp,8
-  mov		eax,[_ds_source]
   mov   ecx,[_ds_colormap]
-  mov   cl,[eax+0x73A]        ;FLATPIXELCOLOR
+  mov   cl,[_ds_flatcolor]
   mov		edx,3c5H
   mov   al,byte [ecx]
   mov		ecx,dword [_ds_x1]
@@ -446,9 +445,8 @@ CODE_SYM_DEF R_DrawSpanFlatLow
 	push	edi
 	push	ebp
 	sub		esp,8
-  mov		eax,[_ds_source]
   mov   ebx,[_ds_colormap]
-  mov   bl,[eax+0x73A]        ;FLATPIXELCOLOR
+  mov   bl,[_ds_flatcolor]
 	mov		ecx,dword [_ds_x1]
   mov   al,byte [ebx]
   mov   ebx,ecx
@@ -539,9 +537,8 @@ CODE_SYM_DEF R_DrawSpanFlatPotato
 	push		ebx
 	push		ecx
 	push		edi
-	mov		eax,[_ds_source]
   mov   ebx,[_ds_colormap]
-  mov   bl,[eax+0x73A]        ;FLATPIXELCOLOR
+  mov   bl,[_ds_flatcolor]
   mov		ecx,[_ds_x2]
   mov		edi,[_ds_x1]
   sub   ecx,edi

--- a/FASTDOOM/r_data.c
+++ b/FASTDOOM/r_data.c
@@ -894,8 +894,7 @@ byte R_GetFlatColor(int flatnum)
     if (flatcolor != R_FLAT_COLOR_UNKNOWN)
         return flatcolor;
 
-    // Use the color found by R_GetFlat, but discard the now unneeded texture image
-    Z_Free(R_GetFlat(flatnum));
+    R_GetFlat(flatnum);
     return flatcolors[flatnum];
 }
 
@@ -903,8 +902,6 @@ byte R_GetFlatColor(int flatnum)
 // R_PrecacheLevel
 // Preloads all relevant graphics for the level.
 //
-int flatmemory;
-
 void R_PrecacheLevel(void)
 {
     char *flatpresent;
@@ -933,14 +930,11 @@ void R_PrecacheLevel(void)
         flatpresent[sectors[i].ceilingpic] = 1;
     }
 
-    flatmemory = 0;
-
     for (i = 0; i < numflats; i++)
     {
         if (flatpresent[i])
         {
             lump = firstflat + i;
-            flatmemory += lumpinfo[lump].size;
             if (visplaneRender == VISPLANES_FLAT || visplaneRender == VISPLANES_FLATTER)
                 R_GetFlatColor(i);
             else

--- a/FASTDOOM/r_data.c
+++ b/FASTDOOM/r_data.c
@@ -111,6 +111,10 @@ int firstflat;
 int lastflat;
 int numflats;
 
+// Bright, but not brightest violet; highly unlikely to be common in the real texture
+#define R_FLAT_COLOR_UNKNOWN ((byte)0xfb)
+byte *flatcolors;
+
 int firstspritelump;
 int lastspritelump;
 int numspritelumps;
@@ -543,11 +547,16 @@ void R_InitFlats(void)
     lastflat = W_GetNumForName("F_END") - 1;
     numflats = lastflat - firstflat + 1;
 
+    // Create color table for non-textured rendering
+    flatcolors = Z_MallocUnowned(numflats, PU_STATIC);
     // Create translation table for global animation.
     flattranslation = Z_MallocUnowned((numflats + 1) * 4, PU_STATIC);
 
     for (i = 0; i < numflats; i++)
+    {
+        flatcolors[i] = R_FLAT_COLOR_UNKNOWN;
         flattranslation[i] = i;
+    }
 }
 
 //
@@ -819,6 +828,78 @@ short R_TextureNumForName(char *name)
 }
 
 //
+// FindDominantByte
+// Find the most common color of given texture to use as a flat replacement
+//
+static byte FindDominantByte(byte *buf, int count)
+{
+    // do NOT ever allocate this array on heap;
+    // that will just slow down loading and increase heap fragmentation
+    int freq[256];
+    int i;
+    int f = 0;
+    byte b;
+
+    SetDWords(freq, 0, 256);
+
+    for (i = 0; i < count; i++)
+        freq[buf[i]]++;
+
+    for (i = 0; i < 256; i++)
+    {
+        if (freq[i] > f)
+        {
+             f = freq[i];
+             b = (byte)i;
+        }
+    }
+    return b;
+}
+
+//
+// R_GetFlat
+// Load flat image and calculate its most common color
+//
+
+byte *R_GetFlat(int flatnum)
+{
+    int lumpnum = firstflat + flatnum;
+    byte *ptr = lumpcache[lumpnum];
+    byte color;
+
+    if (ptr)
+        return ptr;
+
+    ptr = W_CacheLumpNum(lumpnum, PU_CACHE);
+
+    if (flatcolors[flatnum] == R_FLAT_COLOR_UNKNOWN)
+    {
+        color = FindDominantByte(ptr, 4096);
+        if (color == R_FLAT_COLOR_UNKNOWN)
+            color += 1; // relatively safe for default palette
+        flatcolors[flatnum] = color;
+    }
+    return ptr;
+}
+
+//
+// R_GetFlatColor
+// Get a cached color for flat rendering
+//
+
+byte R_GetFlatColor(int flatnum)
+{
+    byte flatcolor = flatcolors[flatnum];
+
+    if (flatcolor != R_FLAT_COLOR_UNKNOWN)
+        return flatcolor;
+
+    // Use the color found by R_GetFlat, but discard the now unneeded texture image
+    Z_Free(R_GetFlat(flatnum));
+    return flatcolors[flatnum];
+}
+
+//
 // R_PrecacheLevel
 // Preloads all relevant graphics for the level.
 //
@@ -860,7 +941,10 @@ void R_PrecacheLevel(void)
         {
             lump = firstflat + i;
             flatmemory += lumpinfo[lump].size;
-            W_CacheLumpNum(lump, PU_CACHE);
+            if (visplaneRender == VISPLANES_FLAT || visplaneRender == VISPLANES_FLATTER)
+                R_GetFlatColor(i);
+            else
+                R_GetFlat(i);
         }
     }
 

--- a/FASTDOOM/r_data.h
+++ b/FASTDOOM/r_data.h
@@ -37,6 +37,9 @@ void R_PrecacheLevel(void);
 // lookup by name. For animation?
 short R_FlatNumForName(char *name);
 
+byte *R_GetFlat(int flatnum);
+byte R_GetFlatColor(int flatnum);
+
 // Called by P_Ticker for switches and animations,
 // returns the texture number for the texture name.
 short R_TextureNumForName(char *name);

--- a/FASTDOOM/r_draw.c
+++ b/FASTDOOM/r_draw.c
@@ -507,7 +507,7 @@ void R_DrawSpanFlatVBE2(void)
     byte *dest;
     int countp;
 
-    lighttable_t color = ds_colormap[ds_source[FLATPIXELCOLOR]];
+    lighttable_t color = ds_colormap[ds_flatcolor];
 
     dest = destview + MulScreenWidth(ds_y) + ds_x1;
 
@@ -533,7 +533,7 @@ void R_DrawSpanFlatLowVBE2(void)
     byte *dest;
     int countp;
 
-    unsigned short color = ds_colormap[ds_source[FLATPIXELCOLOR]];
+    unsigned short color = ds_colormap[ds_flatcolor];
     color |= color << 8;
 
     dest = destview + MulScreenWidth(ds_y) + (ds_x1 << 1);
@@ -560,7 +560,7 @@ void R_DrawSpanFlatPotatoVBE2(void)
     byte *dest;
     int countp;
 
-    unsigned int color = ds_colormap[ds_source[FLATPIXELCOLOR]];
+    unsigned int color = ds_colormap[ds_flatcolor];
     color |= color << 8;
     color |= color << 16;
 
@@ -2751,13 +2751,16 @@ fixed_t ds_step;
 // start of a 64*64 tile image
 byte *ds_source;
 
+// Most common color of the current flat, for non-textured rendering
+byte ds_flatcolor;
+
 #if defined(MODE_T8050) || defined(MODE_T8043)
 void R_DrawSpanFlatText8050(void)
 {
     int countp;
     unsigned short *dest;
 
-    unsigned short color = ds_colormap[ds_source[FLATPIXELCOLOR]] << 8 | 219;
+    unsigned short color = ds_colormap[ds_flatcolor] << 8 | 219;
 
     dest = textdestscreen + Mul80(ds_y) + ds_x1;
 
@@ -2785,7 +2788,7 @@ void R_DrawSpanFlatText4050(void)
 
     odd = ds_y & 1;
     shift = 8 | (odd << 2);
-    color = ds_colormap[ds_source[FLATPIXELCOLOR]];
+    color = ds_colormap[ds_flatcolor];
     color = color << shift | 223;
 
     even = (ds_y + 1) & 1;
@@ -2806,7 +2809,7 @@ void R_DrawSpanFlatText4025(void)
     int countp;
     unsigned short *dest;
 
-    unsigned short color = ds_colormap[ds_source[FLATPIXELCOLOR]] << 8 | 219;
+    unsigned short color = ds_colormap[ds_flatcolor] << 8 | 219;
 
     dest = textdestscreen + Mul40(ds_y) + ds_x1;
 
@@ -2840,7 +2843,7 @@ void R_DrawSpanFlatText8025(void)
 
     odd = ds_y & 1;
     shift = 8 | (odd << 2);
-    color = ds_colormap[ds_source[FLATPIXELCOLOR]];
+    color = ds_colormap[ds_flatcolor];
     color = color << shift | 223;
 
     even = (ds_y + 1) & 1;
@@ -3273,7 +3276,7 @@ void R_DrawSpanFlatBackbuffer(void)
     byte *dest;
     int countp;
 
-    lighttable_t color = ds_colormap[ds_source[FLATPIXELCOLOR]];
+    lighttable_t color = ds_colormap[ds_flatcolor];
 
     dest = ylookup[ds_y] + columnofs[ds_x1];
 
@@ -3299,7 +3302,7 @@ void R_DrawSpanFlatLowBackbuffer(void)
     byte *dest;
     int countp;
 
-    unsigned short color = ds_colormap[ds_source[FLATPIXELCOLOR]];
+    unsigned short color = ds_colormap[ds_flatcolor];
     color |= color << 8;
 
     dest = ylookup[ds_y] + columnofs[ds_x1];
@@ -3326,7 +3329,7 @@ void R_DrawSpanFlatPotatoBackbuffer(void)
     byte *dest;
     int countp;
 
-    unsigned int color = ds_colormap[ds_source[FLATPIXELCOLOR]];
+    unsigned int color = ds_colormap[ds_flatcolor];
     color |= color << 8;
     color |= color << 16;
 

--- a/FASTDOOM/r_draw.h
+++ b/FASTDOOM/r_draw.h
@@ -19,8 +19,6 @@
 #ifndef __R_DRAW__
 #define __R_DRAW__
 
-#define FLATPIXELCOLOR 1850
-
 extern lighttable_t *dc_colormap;
 extern int dc_x;
 extern int dc_yl;
@@ -244,6 +242,9 @@ extern fixed_t ds_step;
 
 // start of a 64*64 tile image
 extern byte *ds_source;
+
+// Most common color of the current flat, for non-textured rendering
+extern byte ds_flatcolor;
 
 // Span blitting for rows, floor/ceiling.
 // No Sepctre effect needed.

--- a/FASTDOOM/r_draw.h
+++ b/FASTDOOM/r_draw.h
@@ -19,8 +19,6 @@
 #ifndef __R_DRAW__
 #define __R_DRAW__
 
-#define FLATPIXELCOLOR 1850
-
 extern lighttable_t *dc_colormap;
 extern int dc_x;
 extern int dc_yl;

--- a/FASTDOOM/r_draw.h
+++ b/FASTDOOM/r_draw.h
@@ -19,6 +19,8 @@
 #ifndef __R_DRAW__
 #define __R_DRAW__
 
+#define FLATPIXELCOLOR 1850
+
 extern lighttable_t *dc_colormap;
 extern int dc_x;
 extern int dc_yl;

--- a/FASTDOOM/r_plane.c
+++ b/FASTDOOM/r_plane.c
@@ -402,7 +402,16 @@ void R_DrawPlanes(void)
         }
 
         // regular flat
-        ds_source = R_GetFlat(flattranslation[pl->picnum]);
+        if (visplaneRender == VISPLANES_FLAT)
+        {
+            // Flat mode only needs the precomputed dominant color,
+            // so the texture image itself is not loaded.
+            ds_flatcolor = R_GetFlatColor(flattranslation[pl->picnum]);
+        }
+        else
+        {
+            ds_source = R_GetFlat(flattranslation[pl->picnum]);
+        }
         planeheight = abs(pl->height - viewz);
         light = (pl->lightlevel >> LIGHTSEGSHIFT) + extralight;
 

--- a/FASTDOOM/r_plane.c
+++ b/FASTDOOM/r_plane.c
@@ -402,8 +402,7 @@ void R_DrawPlanes(void)
         }
 
         // regular flat
-
-        ds_source = W_CacheLumpNum(firstflat + flattranslation[pl->picnum], PU_CACHE);
+        ds_source = R_GetFlat(flattranslation[pl->picnum]);
         planeheight = abs(pl->height - viewz);
         light = (pl->lightlevel >> LIGHTSEGSHIFT) + extralight;
 
@@ -469,7 +468,6 @@ void R_DrawPlanesFlatter(void)
 
     byte color;
     int x;
-    byte *source;
 
     for (pl = visplanes; pl < lastvisplane; pl++)
     {
@@ -483,9 +481,8 @@ void R_DrawPlanesFlatter(void)
             continue;
         }
 
-        source = W_CacheLumpNum(firstflat + flattranslation[pl->picnum], PU_CACHE);
-
-        dc_color = colormaps[source[FLATPIXELCOLOR]];
+        color = R_GetFlatColor(flattranslation[pl->picnum]);
+        dc_color = colormaps[color];
 
         x = pl->minx;
         outp(SC_INDEX + 1, 1 << (x & 3));
@@ -590,7 +587,6 @@ void R_DrawPlanesFlatterLow(void)
 
     byte color;
     int x;
-    byte *source;
 
     for (pl = visplanes; pl < lastvisplane; pl++)
     {
@@ -604,9 +600,9 @@ void R_DrawPlanesFlatterLow(void)
             continue;
         }
 
-        source = W_CacheLumpNum(firstflat + flattranslation[pl->picnum], PU_CACHE);
+        color = R_GetFlatColor(flattranslation[pl->picnum]);
+        dc_color = colormaps[color];
 
-        dc_color = colormaps[source[FLATPIXELCOLOR]];
         // Plane 0
         x = pl->minx;
         outp(SC_INDEX + 1, 3 << ((x & 1) << 1));
@@ -661,7 +657,6 @@ void R_DrawPlanesFlatterPotato(void)
 
     byte color;
     int x;
-    byte *source;
 
     for (pl = visplanes; pl < lastvisplane; pl++)
     {
@@ -675,9 +670,8 @@ void R_DrawPlanesFlatterPotato(void)
             continue;
         }
 
-        source = W_CacheLumpNum(firstflat + flattranslation[pl->picnum], PU_CACHE);
-
-        dc_color = colormaps[source[FLATPIXELCOLOR]];
+        color = R_GetFlatColor(flattranslation[pl->picnum]);
+        dc_color = colormaps[color];
 
         for (x = pl->minx; x <= pl->maxx; x++)
         {
@@ -702,7 +696,7 @@ void R_DrawPlanesFlatterText8050(void)
     unsigned short *dest;
     unsigned short color;
     int x;
-    byte *source;
+    byte flatcolor;
 
     for (pl = visplanes; pl < lastvisplane; pl++)
     {
@@ -716,8 +710,8 @@ void R_DrawPlanesFlatterText8050(void)
             continue;
         }
 
-        source = W_CacheLumpNum(firstflat + flattranslation[pl->picnum], PU_CACHE);
-        color = colormaps[source[FLATPIXELCOLOR]] << 8 | 219;
+        flatcolor = R_GetFlatColor(flattranslation[pl->picnum]);
+        color = colormaps[flatcolor] << 8 | 219;
 
         for (x = pl->minx; x <= pl->maxx; x++)
         {
@@ -761,7 +755,7 @@ void R_DrawPlanesFlatterText4050(void)
     unsigned short colorblock;
     int x;
     byte odd;
-    byte *source;
+    byte flatcolor;
 
     for (pl = visplanes; pl < lastvisplane; pl++)
     {
@@ -775,9 +769,8 @@ void R_DrawPlanesFlatterText4050(void)
             continue;
         }
 
-        source = W_CacheLumpNum(firstflat + flattranslation[pl->picnum], PU_CACHE);
-
-        color = colormaps[source[FLATPIXELCOLOR]];
+        flatcolor = R_GetFlatColor(flattranslation[pl->picnum]);
+        color = colormaps[flatcolor];
         colorblock = color << 8 | 219;
 
         for (x = pl->minx; x <= pl->maxx; x++)
@@ -842,7 +835,7 @@ void R_DrawPlanesFlatterText4025(void)
     unsigned short *dest;
     unsigned short color;
     int x;
-    byte *source;
+    byte flatcolor;
 
     for (pl = visplanes; pl < lastvisplane; pl++)
     {
@@ -856,8 +849,8 @@ void R_DrawPlanesFlatterText4025(void)
             continue;
         }
 
-        source = W_CacheLumpNum(firstflat + flattranslation[pl->picnum], PU_CACHE);
-        color = colormaps[source[FLATPIXELCOLOR]] << 8 | 219;
+        flatcolor = R_GetFlatColor(flattranslation[pl->picnum]);
+        color = colormaps[flatcolor] << 8 | 219;
 
         for (x = pl->minx; x <= pl->maxx; x++)
         {
@@ -900,7 +893,7 @@ void R_DrawPlanesFlatterTextMDA(void)
     unsigned short colorblock;
     int x;
     byte odd;
-    byte *source;
+    byte flatcolor;
 
     for (pl = visplanes; pl < lastvisplane; pl++)
     {
@@ -914,9 +907,8 @@ void R_DrawPlanesFlatterTextMDA(void)
             continue;
         }
 
-        source = W_CacheLumpNum(firstflat + flattranslation[pl->picnum], PU_CACHE);
-
-        color = colormaps[source[FLATPIXELCOLOR]];
+        flatcolor = R_GetFlatColor(flattranslation[pl->picnum]);
+        color = colormaps[flatcolor];
         colorblock = 0x0F << 8 | color;
 
         for (x = pl->minx; x <= pl->maxx; x++)
@@ -979,7 +971,7 @@ void R_DrawPlanesFlatterText8025(void)
     unsigned short colorblock;
     int x;
     byte odd;
-    byte *source;
+    byte flatcolor;
 
     for (pl = visplanes; pl < lastvisplane; pl++)
     {
@@ -993,9 +985,8 @@ void R_DrawPlanesFlatterText8025(void)
             continue;
         }
 
-        source = W_CacheLumpNum(firstflat + flattranslation[pl->picnum], PU_CACHE);
-
-        color = colormaps[source[FLATPIXELCOLOR]];
+        flatcolor = R_GetFlatColor(flattranslation[pl->picnum]);
+        color = colormaps[flatcolor];
         colorblock = color << 8 | 219;
 
         for (x = pl->minx; x <= pl->maxx; x++)
@@ -1058,7 +1049,6 @@ void R_DrawPlanesFlatterBackbuffer(void)
 
     byte color;
     int x;
-    byte *source;
 
     for (pl = visplanes; pl < lastvisplane; pl++)
     {
@@ -1072,9 +1062,8 @@ void R_DrawPlanesFlatterBackbuffer(void)
             continue;
         }
 
-        source = W_CacheLumpNum(firstflat + flattranslation[pl->picnum], PU_CACHE);
-
-        dc_color = colormaps[source[FLATPIXELCOLOR]];
+        color = R_GetFlatColor(flattranslation[pl->picnum]);
+        dc_color = colormaps[color];
 
         for (x = pl->minx; x <= pl->maxx; x++)
         {
@@ -1106,7 +1095,6 @@ void R_DrawPlanesFlatterLowBackbuffer(void)
 
     byte color;
     int x;
-    byte *source;
 
     for (pl = visplanes; pl < lastvisplane; pl++)
     {
@@ -1120,9 +1108,8 @@ void R_DrawPlanesFlatterLowBackbuffer(void)
             continue;
         }
 
-        source = W_CacheLumpNum(firstflat + flattranslation[pl->picnum], PU_CACHE);
-
-        dc_color = colormaps[source[FLATPIXELCOLOR]];
+        color = R_GetFlatColor(flattranslation[pl->picnum]);
+        dc_color = colormaps[color];
 
         for (x = pl->minx; x <= pl->maxx; x++)
         {
@@ -1149,7 +1136,6 @@ void R_DrawPlanesFlatterPotatoBackbuffer(void)
 
     byte color;
     int x;
-    byte *source;
 
     for (pl = visplanes; pl < lastvisplane; pl++)
     {
@@ -1163,9 +1149,8 @@ void R_DrawPlanesFlatterPotatoBackbuffer(void)
             continue;
         }
 
-        source = W_CacheLumpNum(firstflat + flattranslation[pl->picnum], PU_CACHE);
-
-        dc_color = colormaps[source[FLATPIXELCOLOR]];
+        color = R_GetFlatColor(flattranslation[pl->picnum]);
+        dc_color = colormaps[color];
 
         for (x = pl->minx; x <= pl->maxx; x++)
         {
@@ -1190,7 +1175,6 @@ void R_DrawPlanesFlatterVBE2(void)
 
     byte color;
     int x;
-    byte *source;
 
     for (pl = visplanes; pl < lastvisplane; pl++)
     {
@@ -1204,9 +1188,8 @@ void R_DrawPlanesFlatterVBE2(void)
             continue;
         }
 
-        source = W_CacheLumpNum(firstflat + flattranslation[pl->picnum], PU_CACHE);
-
-        dc_color = colormaps[source[FLATPIXELCOLOR]];
+        color = R_GetFlatColor(flattranslation[pl->picnum]);
+        dc_color = colormaps[color];
 
         for (x = pl->minx; x <= pl->maxx; x++)
         {


### PR DESCRIPTION
Improvements for a flat color rendering:
1. Instead of using a fixed texel from a floor/ceiling texture for flat representation, find a most often used color by calculating a frequency histogram (issue #25 ).
2. Keep an array of known colors and discard actual texture images to save RAM.

Histogram is temporarily allocated on stack, but that shouldn't be a problem, because linker script requests 64K of stack.
